### PR TITLE
Release version 0.0.6

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,26 @@
+# wolfCLU v0.0.6 (Nov 09, 2021)
+
+- Add ecparam for ECC key generation with parameters
+- Refactoring of directory names for source and include
+- Refactor return values to use WOLFCLU_SUCCESS
+- Add a logging function for printing messages
+- Add PEM key generation for ECC
+- Add support for parsing a config file when creating a certificate or CSR
+- Refactor all file calls to use XFILE wrapping
+- Refactor strncmp and other system calls to use the X* wrapping
+- Formating on if else newlines throughout wolfCLU
+- Change the name of bundle created with 'make dist'
+- Add some error print outs and checking with FIPS builds
+- Add check for warnings (Wall) as errors and the resulting fixes
+- Static analysis tools ran to test code quality and resulting fixes
+- Refactoring on ECC key generation
+- Changed padding scheme in encrypt and decrypt to interop
+- Add WOLFCLU to variable names and macros
+- Add pkey command
+- Update to req command and expanding its capabilities
+- Add md5 command for creating legacy md5 hashes
+- Add public key print out
+- Convert parsing of input commands to not require '-' in front of them i.e './wolfssl -x509' now can be './wolfssl x509'
+- Add check for libwolfssl to autotools with configure
+- Add --with-wolfssl option to configure to specify location of wolfSSL library
+- Updates to dgst verify command and testing

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 #requires user to have AutoConf version 2.63 or greater.
 AC_PREREQ([2.63])
 
-AC_INIT([wolfclu], [0.0.5], [http://www.wolfssl.com])
+AC_INIT([wolfclu], [0.0.6], [http://www.wolfssl.com])
 
 #a helpful directory to keep clutter out of root
 AC_CONFIG_AUX_DIR([build-aux])
@@ -36,7 +36,6 @@ AC_CONFIG_MACRO_DIR([m4])
 #requires user to have LibTool version 2.2 or greater
 LT_PREREQ([2.2])
 LT_INIT([disable-static],[win32-dll])
-LT_LANG([C++])
 LT_LANG([C])
 
 gl_VISIBILITY
@@ -49,10 +48,8 @@ AS_IF([ test -n "$CFLAG_VISIBILITY" ], [
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
 # Checks for programs.
-AC_PROG_CXX
 AC_PROG_AWK
 AC_PROG_CC
-AC_PROG_CPP
 AC_PROG_CC_C_O
 AC_PROG_INSTALL
 AC_PROG_LN_S

--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,9 @@ AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_LDFLAGS])
 
 # FINAL
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile
+        wolfclu/version.h
+        ])
 
 #AX_CREATE_GENERIC_CONFIG
 AX_AM_JOBSERVER([yes])

--- a/src/clu_main.c
+++ b/src/clu_main.c
@@ -104,6 +104,14 @@ int main(int argc, char** argv)
     }
 #endif
 
+    if (wolfCrypt_Init() != 0) {
+        WOLFCLU_LOG(WOLFCLU_L0, "wolfCyprt initialization failed!");
+        return -1;
+    }
+#ifdef DEBUG_WOLFSSL
+    wolfSSL_Debugging_ON();
+#endif
+
     /* If the first string does not have a '-' in front of it then try to
      * get the mode to use i.e. x509, req, version ... this is for
      * compatibility with the behavior of the OpenSSL command line utility
@@ -205,6 +213,7 @@ int main(int argc, char** argv)
 
     if (ret <= 0)
         WOLFCLU_LOG(WOLFCLU_L0, "Error returned: %d.", ret);
+    wolfCrypt_Cleanup();
 
     /* main function we want to return 0 on success so that the executable
      * returns the expected 0 on success */

--- a/src/sign-verify/clu_dgst_setup.c
+++ b/src/sign-verify/clu_dgst_setup.c
@@ -185,7 +185,7 @@ int wolfCLU_dgst_setup(int argc, char** argv)
         switch (wolfSSL_EVP_PKEY_id(pkey)) {
             case EVP_PKEY_RSA:
                 keySz   = sizeof(RsaKey);
-                sigType = WC_SIGNATURE_TYPE_RSA;
+                sigType = WC_SIGNATURE_TYPE_RSA_W_ENC;
 
                 key = (void*)&rsa;
                 if (wc_InitRsaKey(&rsa, NULL) != 0) {
@@ -193,7 +193,7 @@ int wolfCLU_dgst_setup(int argc, char** argv)
                     ret = WOLFCLU_FATAL_ERROR;
                 }
 
-                if (ret == 0) {
+                if (ret == WOLFCLU_SUCCESS) {
                     derSz = wolfSSL_i2d_PUBKEY(pkey, &der);
                     if (derSz <= 0) {
                         WOLFCLU_LOG(WOLFCLU_L0, "error converting pkey to der");
@@ -201,7 +201,7 @@ int wolfCLU_dgst_setup(int argc, char** argv)
                     }
                 }
 
-                if (ret == 0 &&
+                if (ret == WOLFCLU_SUCCESS &&
                     wc_RsaPublicKeyDecode(der, &idx, &rsa, derSz) != 0) {
                     WOLFCLU_LOG(WOLFCLU_L0, "error decoding public rsa key");
                     ret = WOLFCLU_FATAL_ERROR;

--- a/src/x509/clu_cert_setup.c
+++ b/src/x509/clu_cert_setup.c
@@ -197,7 +197,7 @@ int wolfCLU_certSetup(int argc, char** argv)
 /*---------------------------------------------------------------------------*/
 /* END ARG PROCESSING */
 /*---------------------------------------------------------------------------*/
-    ret = 0;
+    ret = WOLFCLU_SUCCESS;
     switch (error_check(inpemFlag, inderFlag, outpemFlag, outderFlag,
                       textFlag, textPubkey, nooutFlag)) {
         case IN_PEM_OUT_PEM:
@@ -233,7 +233,7 @@ int wolfCLU_certSetup(int argc, char** argv)
             break;
         default:
             WOLFCLU_LOG(WOLFCLU_L0, "Error case");
-            ret = -1;
+            ret = WOLFCLU_FATAL_ERROR;
             break;
     }
 

--- a/src/x509/clu_parse.c
+++ b/src/x509/clu_parse.c
@@ -295,7 +295,7 @@ int wolfCLU_parseFile(char* inFile, int inForm, char* outFile, int outForm,
 
         if (!silentFlag) {
            for (i = 0; i < outBufSz; i++) {
-                WOLFCLU_LOG(WOLFCLU_L0, "%c", outBuf[i]);
+                printf("%c", outBuf[i]);
             }
         }
 

--- a/wolfclu/version.h
+++ b/wolfclu/version.h
@@ -26,8 +26,8 @@
 extern "C" {
 #endif
 
-#define CLUWOLFSSL_VERSION_STRING "0.5"
-#define CLUWOLFSSL_VERSION_HEX 0x00005000
+#define CLUWOLFSSL_VERSION_STRING "0.0.6"
+#define CLUWOLFSSL_VERSION_HEX 0x00000006
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds in a ChangeLog.md, fixes a few return items found during release testing and added in a wolfCrypt init/cleanup.
Also adds in a call to turn on wolfSSL debugging logs if wolfSSL has been compiled with debug enabled.