### PR TITLE
expand x509 command

### DIFF
--- a/src/tools/clu_funcs.c
+++ b/src/tools/clu_funcs.c
@@ -393,6 +393,12 @@ void wolfCLU_benchHelp()
 void wolfCLU_certHelp()
 {
     WOLFCLU_LOG(WOLFCLU_L0, "\n");
+    WOLFCLU_LOG(WOLFCLU_L0, "-subject print out the subject name");
+    WOLFCLU_LOG(WOLFCLU_L0, "-issuer  print out the issuer name");
+    WOLFCLU_LOG(WOLFCLU_L0, "-serial  print out the serial number in hex");
+    WOLFCLU_LOG(WOLFCLU_L0, "-dates   print out the valid dates of cert");
+    WOLFCLU_LOG(WOLFCLU_L0, "-email   print out the subject names email address");
+    WOLFCLU_LOG(WOLFCLU_L0, "-fingerprint print out the hash of the certificate in DER form");
     WOLFCLU_LOG(WOLFCLU_L0, "***************************************************************");
     WOLFCLU_LOG(WOLFCLU_L0, "\nX509 USAGE: wolfssl -x509 -inform <PEM or DER> -in <filename> "
            "-outform <PEM or DER> -out <output file name> \n");

--- a/src/tools/clu_funcs.c
+++ b/src/tools/clu_funcs.c
@@ -399,6 +399,8 @@ void wolfCLU_certHelp()
     WOLFCLU_LOG(WOLFCLU_L0, "-dates   print out the valid dates of cert");
     WOLFCLU_LOG(WOLFCLU_L0, "-email   print out the subject names email address");
     WOLFCLU_LOG(WOLFCLU_L0, "-fingerprint print out the hash of the certificate in DER form");
+    WOLFCLU_LOG(WOLFCLU_L0, "-purpose print out the certificates purpose");
+    WOLFCLU_LOG(WOLFCLU_L0, "-hash print out the hash of the certificate subject name");
     WOLFCLU_LOG(WOLFCLU_L0, "***************************************************************");
     WOLFCLU_LOG(WOLFCLU_L0, "\nX509 USAGE: wolfssl -x509 -inform <PEM or DER> -in <filename> "
            "-outform <PEM or DER> -out <output file name> \n");

--- a/src/x509/clu_ca_setup.c
+++ b/src/x509/clu_ca_setup.c
@@ -218,9 +218,10 @@ int wolfCLU_CASetup(int argc, char** argv)
         ret = wolfCLU_CertSign(signer, x509, ext);
     }
 
+    wolfSSL_BIO_free(reqIn);
     wolfSSL_BIO_free(keyIn);
     wolfSSL_X509_free(x509);
-    wolfSSL_EVP_PKEY_free(pkey);
+    wolfCLU_CertSignFree(signer);
     return ret;
 }
 

--- a/src/x509/clu_cert_setup.c
+++ b/src/x509/clu_cert_setup.c
@@ -253,19 +253,31 @@ int wolfCLU_certSetup(int argc, char** argv)
     }
 
     if (ret == WOLFCLU_SUCCESS && printSerial) {
-        unsigned char serial[32];
-        int  sz = sizeof(serial);
+        unsigned char serial[EXTERNAL_SERIAL_SIZE];
+        int  sz;
         int  i;
 
+        sz = (int)sizeof(serial);
         if (wolfSSL_X509_get_serial_number(x509, serial, &sz) ==
                 WOLFSSL_SUCCESS) {
-            wolfSSL_BIO_write(out, "serial=", (int)XSTRLEN("serail="));
+            if (wolfSSL_BIO_write(out, "serial=", (int)XSTRLEN("serial="))
+                    <= 0) {
+                ret = WOLFCLU_FATAL_ERROR;
+            }
+
             for (i = 0; i < sz; i++) {
                 char scratch[3];
                 XSNPRINTF(scratch, 3, "%02X", serial[i]);
-                wolfSSL_BIO_write(out, scratch, 2);
+                if (ret == WOLFCLU_SUCCESS &&
+                        wolfSSL_BIO_write(out, scratch, 2) <= 0) {
+                    ret = WOLFCLU_FATAL_ERROR;
+                    break;
+                }
             }
-            wolfSSL_BIO_write(out, "\n", (int)XSTRLEN("\n"));
+            if (ret == WOLFCLU_SUCCESS &&
+                    wolfSSL_BIO_write(out, "\n", (int)XSTRLEN("\n")) <= 0) {
+                ret = WOLFCLU_FATAL_ERROR;
+            }
         }
     }
 

--- a/src/x509/clu_config.c
+++ b/src/x509/clu_config.c
@@ -160,6 +160,7 @@ static WOLFSSL_X509_EXTENSION* wolfCLU_parseSubjectKeyID(char* str, int crit,
                     wolfSSL_ASN1_STRING_free(data);
                 }
             }
+	    wolfSSL_EVP_PKEY_free(pkey);
         }
     }
 

--- a/src/x509/clu_parse.c
+++ b/src/x509/clu_parse.c
@@ -142,3 +142,67 @@ int wolfCLU_printX509PubKey(WOLFSSL_X509* x509, WOLFSSL_BIO* out)
     return ret;
 }
 
+
+int wolfCLU_extKeyUsagePrint(WOLFSSL_BIO* bio, unsigned int keyUsage,
+        int indent, int flag)
+{
+    unsigned int ava;
+    char scratch[MAX_TERM_WIDTH];
+
+    if (flag) {
+        XSNPRINTF(scratch, MAX_TERM_WIDTH, "%*s%s\n", indent, "",
+                "Certificate Purpose:");
+        wolfSSL_BIO_write(bio, scratch, (int)XSTRLEN(scratch));
+    }
+
+    ava = (EKU_ANY_OID & keyUsage);
+    if (ava | flag) {
+        XSNPRINTF(scratch, MAX_TERM_WIDTH, "%*s%s%s\n", indent, "",
+                "Any Extended Key Usage",
+                (flag == 1)? (ava > 0) ? " : YES" : " : NO" : "");
+        wolfSSL_BIO_write(bio, scratch, (int)XSTRLEN(scratch));
+    }
+
+    ava = (EKU_SERVER_AUTH_OID & keyUsage);
+    if (ava | flag) {
+        XSNPRINTF(scratch, MAX_TERM_WIDTH, "%*s%s%s\n", indent, "",
+                "TLS Web Server Authentication",
+                (flag == 1)? (ava > 0) ? " : YES" : " : NO" : "");
+        wolfSSL_BIO_write(bio, scratch, (int)XSTRLEN(scratch));
+    }
+
+    ava = (EKU_CLIENT_AUTH_OID & keyUsage);
+    if (ava | flag) {
+        XSNPRINTF(scratch, MAX_TERM_WIDTH, "%*s%s%s\n", indent, "",
+                "TLS Web Client Authentication",
+                (flag == 1)? (ava > 0) ? " : YES" : " : NO" : "");
+        wolfSSL_BIO_write(bio, scratch, (int)XSTRLEN(scratch));
+    }
+
+    ava = (EKU_OCSP_SIGN_OID & keyUsage);
+    if (ava | flag) {
+        XSNPRINTF(scratch, MAX_TERM_WIDTH, "%*s%s%s\n", indent, "",
+                "OCSP Signing",
+                (flag == 1)? (ava > 0) ? " : YES" : " : NO" : "");
+        wolfSSL_BIO_write(bio, scratch, (int)XSTRLEN(scratch));
+    }
+
+    ava = (EKU_EMAILPROTECT_OID & keyUsage);
+    if (ava | flag) {
+        XSNPRINTF(scratch, MAX_TERM_WIDTH, "%*s%s%s\n", indent, "",
+                "Email Protect",
+                (flag == 1)? (ava > 0) ? " : YES" : " : NO" : "");
+        wolfSSL_BIO_write(bio, scratch, (int)XSTRLEN(scratch));
+    }
+
+    ava = (EKU_TIMESTAMP_OID & keyUsage);
+    if (ava | flag) {
+        XSNPRINTF(scratch, MAX_TERM_WIDTH, "%*s%s%s\n", indent, "",
+                "Time Stamp Signing",
+                (flag == 1)? (ava > 0) ? " : YES" : " : NO" : "");
+        wolfSSL_BIO_write(bio, scratch, (int)XSTRLEN(scratch));
+    }
+
+    return WOLFSSL_SUCCESS;
+}
+

--- a/src/x509/clu_request_setup.c
+++ b/src/x509/clu_request_setup.c
@@ -277,13 +277,16 @@ static int _wolfSSL_X509_signature_print_ex(WOLFSSL_BIO* bio,
         int i;
         char tmp[100];
         int sigNid = wolfSSL_X509_get_signature_nid(x509);
+        WOLFSSL_ASN1_OBJECT* obj;
 
         XSNPRINTF(scratch, MAX_WIDTH, "%*s%s", indent, "",
                 "Signature Algorithm: ");
         if (wolfSSL_BIO_write(bio, scratch, (int)XSTRLEN(scratch)) <= 0) {
             return WOLFSSL_FAILURE;
         }
-        wolfSSL_OBJ_obj2txt(scratch, MAX_WIDTH, wolfSSL_OBJ_nid2obj(sigNid), 0);
+        obj = wolfSSL_OBJ_nid2obj(sigNid);
+        wolfSSL_OBJ_obj2txt(scratch, MAX_WIDTH, obj, 0);
+        wolfSSL_ASN1_OBJECT_free(obj);
         XSNPRINTF(tmp, sizeof(tmp) - 1,"%s\n", scratch);
         tmp[sizeof(tmp) - 1] = '\0';
         if (wolfSSL_BIO_write(bio, tmp, (int)XSTRLEN(tmp)) <= 0) {
@@ -354,6 +357,7 @@ static int _wolfSSL_X509_pubkey_print(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
 
     pubKey = wolfSSL_X509_get_pubkey(x509);
     wolfSSL_EVP_PKEY_print_public(bio, pubKey, indent + 4, NULL);
+    wolfSSL_EVP_PKEY_free(pubKey);
     return WOLFSSL_SUCCESS;
 }
 
@@ -857,6 +861,7 @@ int wolfCLU_requestSetup(int argc, char** argv)
         }
     }
 
+    wolfSSL_BIO_free(reqIn);
     wolfSSL_BIO_free(keyIn);
     wolfSSL_BIO_free(bioOut);
     wolfSSL_X509_free(x509);

--- a/tests/x509/x509-process-test.sh
+++ b/tests/x509/x509-process-test.sh
@@ -123,6 +123,64 @@ run3() {
     cert_test_case "-inform pem -outform der -in certs/ca-cert.pem -out tmp.der" \
                     test.der tmp.der
     rm -f test.pem tmp.pem
+    echo "TEST 3.c"
+    test_case "-in certs/server-cert.pem -subject -noout"
+    EXPECTED="/C=US/ST=Montana/L=Bozeman/O=wolfSSL/OU=Support/CN=www.wolfssl.com/emailAddress=info@wolfssl.com"
+    if [ "$OUTPUT" != "$EXPECTED" ]; then
+        echo "found unexpected $OUTPUT"
+        echo "expected $EXPECTED"
+        exit 99
+    fi
+    echo "TEST 3.d"
+    test_case "-in certs/server-cert.pem -issuer -noout"
+    EXPECTED="/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com"
+    if [ "$OUTPUT" != "$EXPECTED" ]; then
+        echo "found unexpected $OUTPUT"
+        echo "expected $EXPECTED"
+        exit 99
+    fi
+    echo "TEST 3.e"
+    test_case "-in certs/ca-cert.pem -serial -noout"
+    EXPECTED="serial=7D947088BA07428DAAAF4FBEC21A48F0D140E642"
+    if [ "$OUTPUT" != "$EXPECTED" ]; then
+        echo "found unexpected $OUTPUT"
+        echo "expected $EXPECTED"
+        exit 99
+    fi
+    echo "TEST 3.f"
+    test_case "-in certs/server-cert.pem -serial -noout"
+    EXPECTED="serial=01"
+    if [ "$OUTPUT" != "$EXPECTED" ]; then
+        echo "found unexpected $OUTPUT"
+        echo "expected $EXPECTED"
+        exit 99
+    fi
+    echo "TEST 3.g"
+    test_case "-in certs/server-cert.pem -dates -noout"
+    EXPECTED="notBefore=Dec 20 23:07:25 2021 GMT
+notAfter=Sep 15 23:07:25 2024 GMT"
+    if [ "$OUTPUT" != "$EXPECTED" ]; then
+        echo "found unexpected $OUTPUT"
+        echo "expected $EXPECTED"
+        exit 99
+    fi
+    echo "TEST 3.h"
+    test_case "-in certs/server-cert.pem -email -noout"
+    EXPECTED="info@wolfssl.com"
+    if [ "$OUTPUT" != "$EXPECTED" ]; then
+        echo "found unexpected $OUTPUT"
+        echo "expected $EXPECTED"
+        exit 99
+    fi
+    echo "TEST 3.i"
+    test_case "-in certs/server-cert.pem -fingerprint -noout"
+    EXPECTED="SHA1 of cert. DER : 52686B24F54652F04B0D87BA9F591B393C86C407"
+    if [ "$OUTPUT" != "$EXPECTED" ]; then
+        echo "found unexpected $OUTPUT"
+        echo "expected $EXPECTED"
+        exit 99
+    fi
+
 }
 
 run4() {
@@ -162,3 +220,6 @@ run4
 rm -f out.txt
 rm -f tmp.pem
 rm -f tmp.der
+
+echo "Done"
+exit 0

--- a/tests/x509/x509-process-test.sh
+++ b/tests/x509/x509-process-test.sh
@@ -180,7 +180,29 @@ notAfter=Sep 15 23:07:25 2024 GMT"
         echo "expected $EXPECTED"
         exit 99
     fi
-
+    echo "TEST 3.j"
+    test_case "-in certs/server-cert.pem -purpose -noout"
+    EXPECTED="Certificate Purpose:
+Any Extended Key Usage : YES
+TLS Web Server Authentication : YES
+TLS Web Client Authentication : NO
+OCSP Signing : YES
+Email Protect : YES
+Time Stamp Signing : YES"
+    if [ "$OUTPUT" != "$EXPECTED" ]; then
+        echo "found unexpected $OUTPUT"
+        echo "expected $EXPECTED"
+        exit 99
+    fi
+    echo "TEST 3.k"
+    test_case "-in certs/server-cert.pem -hash -noout"
+    EXPECTED="Not canon version of subject:
+f6cf410e"
+    if [ "$OUTPUT" != "$EXPECTED" ]; then
+        echo "found unexpected $OUTPUT"
+        echo "expected $EXPECTED"
+        exit 99
+    fi
 }
 
 run4() {

--- a/wolfclu/clu_header_main.h
+++ b/wolfclu/clu_header_main.h
@@ -85,6 +85,7 @@
 
 #define BLOCK_SIZE 16384
 #define MEGABYTE (1024*1024)
+#define MAX_TERM_WIDTH 80
 #define MAX_THREADS 64
 #define MAX_FILENAME_SZ 256
 #define CLU_4K_TYPE 4096

--- a/wolfclu/x509/clu_parse.h
+++ b/wolfclu/x509/clu_parse.h
@@ -70,4 +70,17 @@ int wolfCLU_printDer(WOLFSSL_BIO* bio, unsigned char* der, int derSz,
  * @return returns WOLFCLU_SUCCESS on success
  */
 int wolfCLU_printX509PubKey(WOLFSSL_X509* x509, WOLFSSL_BIO* out);
+
+/**
+ * @brief prints out extended key usage
+ *
+ * @param bio output bio
+ * @param keyUsage bit map of key usage
+ * @param indent number of leading spaces
+ * @param flag if printing out NO for not supported items
+ *
+ * @return returns WOLFCLU_SUCCESS on success
+ */
+int wolfCLU_extKeyUsagePrint(WOLFSSL_BIO* bio, unsigned int keyUsage,
+        int indent, int flag);
 #endif /* WOLFCLU_PARSE_H */


### PR DESCRIPTION
Adds support to the x509 command for:

- -subject
- -issuer
- -serial
- -dates
- -email
- -fingerprint
- -purpose
- -hash (note that wolfSSL_X509_NAME_hash does not match up with OpenSSL, needs investigating in wolfSSL library)