### PR TITLE
Porting over to windows

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -1,0 +1,64 @@
+name: Windows Build Test
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  WOLFSSL_SOLUTION_FILE_PATH: wolfssl/wolfssl64.sln 
+  SOLUTION_FILE_PATH: wolfclu.sln
+  USER_SETTINGS_H_NEW: wolfclu/ide/winvs/user_settings.h
+  USER_SETTINGS_H: wolfssl/IDE/WIN/user_settings.h
+  INCLUDE_DIR: wolfclu
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  WOLFSSL_BUILD_CONFIGURATION: Release
+  WOLFCLU_BUILD_CONFIGURATION: Release
+  BUILD_PLATFORM: x64
+  TARGET_PLATFORM: 10 
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: wolfssl/wolfssl
+        path: wolfssl 
+        
+    - uses: actions/checkout@master
+      with: 
+        path: wolfclu
+    
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Restore wolfSSL NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.WOLFSSL_SOLUTION_FILE_PATH}}
+      
+    - name: replace with wolfCLU user_settings.h
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cp ${{env.USER_SETTINGS_H_NEW}} ${{env.USER_SETTINGS_H}} 
+    
+    - name: Build wolfssl
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:PlatformToolset=v142 /p:Platform=${{env.BUILD_PLATFORM}} /p:WindowsTargetPlatformVersion=${{env.TARGET_PLATFORM}} /p:Configuration=${{env.WOLFSSL_BUILD_CONFIGURATION}} ${{env.WOLFSSL_SOLUTION_FILE_PATH}}
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}wolfclu
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+   
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}wolfclu
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:PlatformToolset=v142 /p:Platform=${{env.BUILD_PLATFORM}} /p:WindowsTargetPlatformVersion=${{env.TARGET_PLATFORM}} /p:Configuration=${{env.WOLFCLU_BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}} 

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,9 @@ EXTRA_DIST+= manpages
 EXTRA_DIST+= README.md
 EXTRA_DIST+= LICENSE
 EXTRA_DIST+= ChangeLog.md
+EXTRA_DIST+= wolfclu.sln
+EXTRA_DIST+= wolfCLU.vcxproj
+EXTRA_DIST+= wolfCLU.vcxproj.filters
 
 man_MANS+= manpages/wolfCLU_benchmark.1
 man_MANS+= manpages/wolfCLU_decrypt.1
@@ -53,6 +56,7 @@ include tests/encrypt/include.am
 include tests/genkey_sign_ver/include.am
 include tests/hash/include.am
 include tests/bench/include.am
+include ide/include.am
 #####include data/include.am
 
 

--- a/ide/include.am
+++ b/ide/include.am
@@ -1,0 +1,5 @@
+# vim:ft=automake
+# included from top level Makefile.am
+# ALl path should be given relative to root directory
+
+include ide/winvs/include.am

--- a/ide/winvs/README.md
+++ b/ide/winvs/README.md
@@ -1,0 +1,38 @@
+VisualStudio solution for wolfCLU
+=================================
+
+The solution file, wolfclu.sln, facilitates bulding wolfCLU.
+The solution provides both Debug and Release
+builds of Dynamic 32- or 64-bit libraries. The file
+`user_settings.h` should be used in the wolfSSL build to configure it.
+
+The file `wolfclu\ide\winvs\user_settings.h` contains the settings used to
+configure wolfSSL with the appropriate settings. This file must be copied
+from the directory `wolfclu\ide\winvs` to `wolfssl\IDE\WIN`. You can then 
+build wolfSSL with support for wolfCLU. 
+
+Before building wolfCLU, Make sure you have the same architecture (Win32 or
+x64) selected as used in wolfSSL.
+
+This project assumes that the wolfSSH and wolfSSL source directories
+are installed side-by-side and do not have the version number in their
+names:
+
+    Projects\
+        wolfclu\
+        wolfssl\
+
+Building wolfCLU a release configuration will generate `wolfssl.exe` in the 
+`Release\Win32` or `Release\x64` directory. 
+
+Running Unit Tests
+------------------
+To run the shell-script unit tests, you will need either the `sh` or `bash`
+commands, both of which come with a Git installation on Windows (although you
+may have to add them to the PATH). 
+
+1. Copy the `wolfssl.exe` to the root directory of wolfclu.
+2. Modify the `run` function (as well as `run_fail`, if present) of the desired 
+unit test to run `./wolfssl.exe $1` instead of `./wolfssl $1`.
+3. In your terminal, run `sh <desired_unit_test>` from the root directory. For 
+instance, to run the hash unit tests, run `sh tests\hash\hash-test.sh`.

--- a/ide/winvs/include.am
+++ b/ide/winvs/include.am
@@ -1,0 +1,6 @@
+# vim:ft=automake
+# included from top level Makefile.am
+# ALl path should be given relative to root directory
+
+EXTRA_DIST+=ide/winvs/README.md
+EXTRA_DIST+=ide/winvs/user_settings.h

--- a/ide/winvs/user_settings.h
+++ b/ide/winvs/user_settings.h
@@ -1,0 +1,31 @@
+#ifndef _WIN_USER_SETTINGS_H_
+#define _WIN_USER_SETTINGS_H_
+
+/* Verify this is Windows */
+#ifndef _WIN32
+#error This user_settings.h header is only designed for Windows
+#endif
+
+#define WC_RSA_BLINDING
+#define NO_MULTIBYTE_PRINT
+#define WC_NO_HARDEN
+
+#define WOLFSSL_KEY_GEN
+#define WOLFSSL_CERT_GEN
+#define WOLFSSL_CERT_REQ
+#define WOLFSSL_CERT_EXT
+#define HAVE_ECC
+#define HAVE_DH
+#define HAVE_ED25519
+#define WOLFSSL_AES_COUNTER
+#define WOLFSSL_AES_DIRECT
+#define HAVE_AESGCM
+#define WOLFSSL_SHA224
+#define WOLFSSL_SHA384
+#define WOLFSSL_SHA512
+
+#define HAVE_TLS_EXTENSIONS
+#define OPENSSL_ALL
+#define OPENSSL_EXTRA
+
+#endif /* _WIN_USER_SETTINGS_H_ */

--- a/src/benchmark/clu_benchmark.c
+++ b/src/benchmark/clu_benchmark.c
@@ -62,8 +62,6 @@ int wolfCLU_benchmark(int timer, int* option)
 
     wc_InitRng(&rng);
 
-    signal(SIGALRM, wolfCLU_stop);
-
     /* @fragile:
      * this function assumes that it perfectly knows the order and length of
      * the option array in clu_src/benchmark/clu_bench_setup.c. Looping over a
@@ -99,7 +97,6 @@ int wolfCLU_benchmark(int timer, int* option)
         wc_RNG_GenerateBlock(&rng, key, AES_BLOCK_SIZE);
         wc_RNG_GenerateBlock(&rng, iv, AES_BLOCK_SIZE);
         start = wolfCLU_getTime();
-        alarm(timer);
 
         wc_AesSetKey(&aes, key, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
 
@@ -153,7 +150,6 @@ int wolfCLU_benchmark(int timer, int* option)
         wc_RNG_GenerateBlock(&rng, key, AES_BLOCK_SIZE);
         wc_RNG_GenerateBlock(&rng, iv, AES_BLOCK_SIZE);
         start = wolfCLU_getTime();
-        alarm(timer);
 
         wc_AesSetKeyDirect(&aes, key, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
         while (loop) {
@@ -206,7 +202,6 @@ int wolfCLU_benchmark(int timer, int* option)
         wc_RNG_GenerateBlock(&rng, iv, DES3_BLOCK_SIZE);
 
         start = wolfCLU_getTime();
-        alarm(timer);
 
         wc_Des3_SetKey(&des3, key, iv, DES_ENCRYPTION);
         while (loop) {
@@ -262,7 +257,6 @@ int wolfCLU_benchmark(int timer, int* option)
         wc_RNG_GenerateBlock(&rng, iv, CAMELLIA_BLOCK_SIZE);
 
         start = wolfCLU_getTime();
-        alarm(timer);
 
         wc_CamelliaSetKey(&camellia, key, CAMELLIA_BLOCK_SIZE, iv);
         while (loop) {
@@ -304,7 +298,6 @@ int wolfCLU_benchmark(int timer, int* option)
 
         wc_InitMd5(&md5);
         start = wolfCLU_getTime();
-        alarm(timer);
 
         while (loop) {
             wc_Md5Update(&md5, plain, MEGABYTE);
@@ -344,7 +337,6 @@ int wolfCLU_benchmark(int timer, int* option)
 
         wc_InitSha(&sha);
         start = wolfCLU_getTime();
-        alarm(timer);
 
         while (loop) {
             wc_ShaUpdate(&sha, plain, MEGABYTE);
@@ -385,7 +377,6 @@ int wolfCLU_benchmark(int timer, int* option)
 
         wc_InitSha256(&sha256);
         start = wolfCLU_getTime();
-        alarm(timer);
 
         while (loop) {
             wc_Sha256Update(&sha256, plain, MEGABYTE);
@@ -427,7 +418,6 @@ int wolfCLU_benchmark(int timer, int* option)
 
         wc_InitSha384(&sha384);
         start = wolfCLU_getTime();
-        alarm(timer);
 
         while (loop) {
             wc_Sha384Update(&sha384, plain, MEGABYTE);
@@ -468,7 +458,6 @@ int wolfCLU_benchmark(int timer, int* option)
 
         wc_InitSha512(&sha512);
         start = wolfCLU_getTime();
-        alarm(timer);
 
         while (loop) {
             wc_Sha512Update(&sha512, plain, MEGABYTE);
@@ -508,7 +497,6 @@ int wolfCLU_benchmark(int timer, int* option)
 
         wc_InitBlake2b(&b2b, BLAKE2B_OUTBYTES);
         start = wolfCLU_getTime();
-        alarm(timer);
 
         while (loop) {
             wc_Blake2bUpdate(&b2b, plain, MEGABYTE);

--- a/src/client/clu_client_setup.c
+++ b/src/client/clu_client_setup.c
@@ -88,7 +88,7 @@ int wolfCLU_Client(int argc, char** argv)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "", client_options,
+    while ((option = wolfCLU_GetOpt(argc, argv, "", client_options,
                     &longIndex )) != -1) {
         switch (option) {
             case WOLFCLU_CONNECT:

--- a/src/clu_main.c
+++ b/src/clu_main.c
@@ -29,6 +29,14 @@
 #include <wolfclu/pkey/clu_pkey.h>
 #include <wolfclu/sign-verify/clu_sign_verify_setup.h>
 #include <wolfclu/sign-verify/clu_verify.h>
+
+#ifdef _WIN32 
+char* optarg;
+int   optind ;
+int   opterr ;
+#endif
+
+
 /* enumerate optionals beyond ascii range to dis-allow use of alias IE we
  * do not want "-e" to work for encrypt, user must use "encrypt"
  */
@@ -156,19 +164,22 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    /* If the first string does not have a '-' in front of it then try to
-     * get the mode to use i.e. x509, req, version ... this is for
-     * compatibility with the behavior of the OpenSSL command line utility
-     */
-    if (argc > 1 && argv[1] != NULL && argv[1][0] != '-') {
+    optind = 0;
+
+    /* retain old version of modes where '-' is used. i.e -x509, -req */
+    if (argc > 1 && argv[1] != NULL && argv[1][0] == '-') {
+        argv[1] = argv[1] + 1; 
         flag = getMode(argv[1]);
-    }
-    else {
-        /* retain old version of modes where '-' is used. i.e -x509, -req */
-        flag = getopt_long_only(argc, argv,"", mode_options, &longIndex);
 
         /* if -rsa was used then it is the older sign/verify version of rsa */
         if (flag == WOLFCLU_RSA) flag = WOLFCLU_RSALEGACY;
+    }
+   /* If the first string does not have a '-' in front of it then try to
+     * get the mode to use i.e. x509, req, version ... this is for
+     * compatibility with the behavior of the OpenSSL command line utility
+     */
+    else {
+        flag = wolfCLU_GetOpt(argc, argv,"", mode_options, &longIndex);
     }
 
     switch (flag) {

--- a/src/crypto/clu_crypto_setup.c
+++ b/src/crypto/clu_crypto_setup.c
@@ -24,26 +24,26 @@
 #include <wolfclu/clu_optargs.h>
 
 static const struct option crypt_options[] = {
-    {"sha",       no_argument,       0, WOLFCLU_CERT_SHA   },
-    {"sha224",    no_argument,       0, WOLFCLU_CERT_SHA224},
-    {"sha256",    no_argument,       0, WOLFCLU_CERT_SHA256},
-    {"sha384",    no_argument,       0, WOLFCLU_CERT_SHA384},
-    {"sha512",    no_argument,       0, WOLFCLU_CERT_SHA512},
+    {"-sha",       no_argument,       0, WOLFCLU_CERT_SHA   },
+    {"-sha224",    no_argument,       0, WOLFCLU_CERT_SHA224},
+    {"-sha256",    no_argument,       0, WOLFCLU_CERT_SHA256},
+    {"-sha384",    no_argument,       0, WOLFCLU_CERT_SHA384},
+    {"-sha512",    no_argument,       0, WOLFCLU_CERT_SHA512},
 
-    {"in",        required_argument, 0, WOLFCLU_INFILE    },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE   },
-    {"pwd",       required_argument, 0, WOLFCLU_PASSWORD  },
-    {"key",       required_argument, 0, WOLFCLU_KEY       },
-    {"iv",        required_argument, 0, WOLFCLU_IV        },
-    {"inkey",     required_argument, 0, WOLFCLU_INKEY     },
-    {"output",    required_argument, 0, WOLFCLU_OUTPUT    },
-    {"pbkdf2",    no_argument,       0, WOLFCLU_PBKDF2    },
-    {"md",        required_argument, 0, WOLFCLU_MD        },
-    {"d",         no_argument,       0, WOLFCLU_DECRYPT   },
-    {"p",         no_argument,       0, WOLFCLU_DEBUG     },
-    {"k",         required_argument, 0, WOLFCLU_PASSWORD  },
-    {"base64",    no_argument,       0, WOLFCLU_BASE64    },
-    {"nosalt",    no_argument,       0, WOLFCLU_NOSALT    },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE    },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE   },
+    {"-pwd",       required_argument, 0, WOLFCLU_PASSWORD  },
+    {"-key",       required_argument, 0, WOLFCLU_KEY       },
+    {"-iv",        required_argument, 0, WOLFCLU_IV        },
+    {"-inkey",     required_argument, 0, WOLFCLU_INKEY     },
+    {"-output",    required_argument, 0, WOLFCLU_OUTPUT    },
+    {"-pbkdf2",    no_argument,       0, WOLFCLU_PBKDF2    },
+    {"-md",        required_argument, 0, WOLFCLU_MD        },
+    {"-d",         no_argument,       0, WOLFCLU_DECRYPT   },
+    {"-p",         no_argument,       0, WOLFCLU_DEBUG     },
+    {"-k",         required_argument, 0, WOLFCLU_PASSWORD  },
+    {"-base64",    no_argument,       0, WOLFCLU_BASE64    },
+    {"-nosalt",    no_argument,       0, WOLFCLU_NOSALT    },
     {0, 0, 0, 0} /* terminal element */
 };
 
@@ -88,7 +88,7 @@ int wolfCLU_setup(int argc, char** argv, char action)
                                  * reading a hex string passed in */
     word32   numBits    =   0;  /* number of bits in argument from the user */
     int      option;
-    int      longIndex = 0;
+    int      longIndex = 1;
 
     if (action == 'e')
         encCheck = 1;
@@ -136,7 +136,7 @@ int wolfCLU_setup(int argc, char** argv, char action)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "",
+    while ((option = wolfCLU_GetOpt(argc, argv, "",
                    crypt_options, &longIndex )) != -1) {
 
         switch (option) {

--- a/src/dh/clu_dh.c
+++ b/src/dh/clu_dh.c
@@ -35,13 +35,13 @@
 #endif
 
 static const struct option dh_options[] = {
-    {"in",        required_argument, 0, WOLFCLU_INFILE    },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE   },
-    {"genkey",    no_argument,       0, WOLFCLU_GEN_KEY   },
-    {"check",     no_argument,       0, WOLFCLU_CHECK     },
-    {"noout",     no_argument,       0, WOLFCLU_NOOUT     },
-    {"help",      no_argument,       0, WOLFCLU_HELP      },
-    {"h",         no_argument,       0, WOLFCLU_HELP      },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE    },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE   },
+    {"-genkey",    no_argument,       0, WOLFCLU_GEN_KEY   },
+    {"-check",     no_argument,       0, WOLFCLU_CHECK     },
+    {"-noout",     no_argument,       0, WOLFCLU_NOOUT     },
+    {"-help",      no_argument,       0, WOLFCLU_HELP      },
+    {"-h",         no_argument,       0, WOLFCLU_HELP      },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -88,7 +88,7 @@ int wolfCLU_DhParamSetup(int argc, char** argv)
     }
 
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "",
+    while ((option = wolfCLU_GetOpt(argc, argv, "",
                    dh_options, &longIndex )) != -1) {
         switch (option) {
             case WOLFCLU_INFILE:

--- a/src/dsa/clu_dsa.c
+++ b/src/dsa/clu_dsa.c
@@ -25,12 +25,12 @@
 
 #ifndef NO_DSA
 static const struct option dsa_options[] = {
-    {"in",        required_argument, 0, WOLFCLU_INFILE    },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE   },
-    {"genkey",    no_argument,       0, WOLFCLU_GEN_KEY   },
-    {"noout",     no_argument,       0, WOLFCLU_NOOUT     },
-    {"help",      no_argument,       0, WOLFCLU_HELP      },
-    {"h",         no_argument,       0, WOLFCLU_HELP      },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE    },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE   },
+    {"-genkey",    no_argument,       0, WOLFCLU_GEN_KEY   },
+    {"-noout",     no_argument,       0, WOLFCLU_NOOUT     },
+    {"-help",      no_argument,       0, WOLFCLU_HELP      },
+    {"-h",         no_argument,       0, WOLFCLU_HELP      },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -75,7 +75,7 @@ int wolfCLU_DsaParamSetup(int argc, char** argv)
     }
 
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "",
+    while ((option = wolfCLU_GetOpt(argc, argv, "",
                    dsa_options, &longIndex )) != -1) {
         switch (option) {
             case WOLFCLU_INFILE:

--- a/src/ecparam/clu_ecparam.c
+++ b/src/ecparam/clu_ecparam.c
@@ -30,13 +30,13 @@
 #endif
 
 static const struct option ecparam_options[] = {
-    {"in",        required_argument, 0, WOLFCLU_INFILE    },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE   },
-    {"inform",    required_argument, 0, WOLFCLU_INFORM    },
-    {"outform",   required_argument, 0, WOLFCLU_OUTFORM   },
-    {"genkey",    no_argument,       0, WOLFCLU_GEN_KEY    },
-    {"name",      required_argument, 0, WOLFCLU_CURVE_NAME },
-    {"text",      no_argument,       0, WOLFCLU_TEXT_OUT },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE    },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE   },
+    {"-inform",    required_argument, 0, WOLFCLU_INFORM    },
+    {"-outform",   required_argument, 0, WOLFCLU_OUTFORM   },
+    {"-genkey",    no_argument,       0, WOLFCLU_GEN_KEY    },
+    {"-name",      required_argument, 0, WOLFCLU_CURVE_NAME },
+    {"-text",      no_argument,       0, WOLFCLU_TEXT_OUT },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -71,7 +71,7 @@ int wolfCLU_ecparam(int argc, char** argv)
     char* name = NULL;
     char* out  = NULL;    /* default output file name */
     int   ret        = WOLFCLU_SUCCESS;
-    int   longIndex  = 0;
+    int   longIndex  = 1;
     int   genKey     = 0;
     int   textOut    = 0;
     int   outForm    = PEM_FORM;
@@ -89,7 +89,7 @@ int wolfCLU_ecparam(int argc, char** argv)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "",
+    while ((option = wolfCLU_GetOpt(argc, argv, "",
                    ecparam_options, &longIndex )) != -1) {
 
         switch (option) {

--- a/src/genkey/clu_genkey.c
+++ b/src/genkey/clu_genkey.c
@@ -19,7 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/asn_public.h> /* wc_DerToPem */
 
 #if defined(WOLFSSL_KEY_GEN) && !defined(NO_ASN)

--- a/src/pkcs/clu_pkcs12.c
+++ b/src/pkcs/clu_pkcs12.c
@@ -27,15 +27,15 @@
 #include <wolfclu/x509/clu_parse.h>
 
 static const struct option pkcs12_options[] = {
-    {"nodes",     no_argument, 0, WOLFCLU_NODES   },
-    {"nocerts",   no_argument, 0, WOLFCLU_NOCERTS },
-    {"nokeys",    no_argument, 0, WOLFCLU_NOKEYS  },
-    {"passin",    required_argument, 0, WOLFCLU_PASSWORD     },
-    {"passout",   required_argument, 0, WOLFCLU_PASSWORD_OUT },
-    {"in",        required_argument, 0, WOLFCLU_INFILE       },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE      },
-    {"help",      no_argument, 0, WOLFCLU_HELP},
-    {"h",         no_argument, 0, WOLFCLU_HELP},
+    {"-nodes",     no_argument, 0, WOLFCLU_NODES   },
+    {"-nocerts",   no_argument, 0, WOLFCLU_NOCERTS },
+    {"-nokeys",    no_argument, 0, WOLFCLU_NOKEYS  },
+    {"-passin",    required_argument, 0, WOLFCLU_PASSWORD     },
+    {"-passout",   required_argument, 0, WOLFCLU_PASSWORD_OUT },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE       },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE      },
+    {"-help",      no_argument, 0, WOLFCLU_HELP},
+    {"-h",         no_argument, 0, WOLFCLU_HELP},
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -74,7 +74,7 @@ int wolfCLU_PKCS12(int argc, char** argv)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "",
+    while ((option = wolfCLU_GetOpt(argc, argv, "",
                    pkcs12_options, &longIndex )) != -1) {
         switch (option) {
             case WOLFCLU_NODES:

--- a/src/pkey/clu_pkey.c
+++ b/src/pkey/clu_pkey.c
@@ -28,14 +28,14 @@
 #include <wolfclu/x509/clu_parse.h>
 
 static const struct option pkey_options[] = {
-    {"in",        required_argument, 0, WOLFCLU_INFILE    },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE   },
-    {"inform",    required_argument, 0, WOLFCLU_INFORM    },
-    {"outform",   required_argument, 0, WOLFCLU_OUTFORM   },
-    {"pubout",    no_argument,       0, WOLFCLU_PUBOUT    },
-    {"pubin",     no_argument,       0, WOLFCLU_PUBIN     },
-    {"help",      no_argument,       0, WOLFCLU_HELP      },
-    {"h",         no_argument,       0, WOLFCLU_HELP      },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE    },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE   },
+    {"-inform",    required_argument, 0, WOLFCLU_INFORM    },
+    {"-outform",   required_argument, 0, WOLFCLU_OUTFORM   },
+    {"-pubout",    no_argument,       0, WOLFCLU_PUBOUT    },
+    {"-pubin",     no_argument,       0, WOLFCLU_PUBIN     },
+    {"-help",      no_argument,       0, WOLFCLU_HELP      },
+    {"-h",         no_argument,       0, WOLFCLU_HELP      },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -421,7 +421,7 @@ int wolfCLU_pKeySetup(int argc, char** argv)
     WOLFSSL_BIO *bioOut = NULL;
 
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "",
+    while ((option = wolfCLU_GetOpt(argc, argv, "",
                    pkey_options, &longIndex )) != -1) {
         switch (option) {
             case WOLFCLU_PUBOUT:

--- a/src/pkey/clu_rsa.c
+++ b/src/pkey/clu_rsa.c
@@ -27,16 +27,16 @@
 #include <wolfclu/x509/clu_parse.h>
 
 static const struct option rsa_options[] = {
-    {"in",        required_argument, 0, WOLFCLU_INFILE    },
-    {"inform",    required_argument, 0, WOLFCLU_INFORM    },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE   },
-    {"outform",   required_argument, 0, WOLFCLU_OUTFORM   },
-    {"passin",    required_argument, 0, WOLFCLU_PASSWORD  },
-    {"noout",     no_argument,       0, WOLFCLU_NOOUT     },
-    {"modulus",   no_argument,       0, WOLFCLU_MODULUS   },
-    {"RSAPublicKey_in", no_argument, 0, WOLFCLU_RSAPUBIN  },
-    {"help",      no_argument,       0, WOLFCLU_HELP      },
-    {"h",         no_argument,       0, WOLFCLU_HELP      },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE    },
+    {"-inform",    required_argument, 0, WOLFCLU_INFORM    },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE   },
+    {"-outform",   required_argument, 0, WOLFCLU_OUTFORM   },
+    {"-passin",    required_argument, 0, WOLFCLU_PASSWORD  },
+    {"-noout",     no_argument,       0, WOLFCLU_NOOUT     },
+    {"-modulus",   no_argument,       0, WOLFCLU_MODULUS   },
+    {"-RSAPublicKey_in", no_argument, 0, WOLFCLU_RSAPUBIN  },
+    {"-help",      no_argument,       0, WOLFCLU_HELP      },
+    {"-h",         no_argument,       0, WOLFCLU_HELP      },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -75,7 +75,7 @@ int wolfCLU_RSA(int argc, char** argv)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "",
+    while ((option = wolfCLU_GetOpt(argc, argv, "",
                    rsa_options, &longIndex )) != -1) {
         switch (option) {
             case WOLFCLU_INFILE:

--- a/src/sign-verify/clu_crl_verify.c
+++ b/src/sign-verify/clu_crl_verify.c
@@ -28,14 +28,14 @@
 
 #ifdef HAVE_CRL
 static const struct option crl_options[] = {
-    {"in",        required_argument, 0, WOLFCLU_INFILE    },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE   },
-    {"inform",    required_argument, 0, WOLFCLU_INFORM    },
-    {"outform",   required_argument, 0, WOLFCLU_OUTFORM   },
-    {"CAfile",    required_argument, 0, WOLFCLU_CAFILE    },
-    {"noout",     no_argument,       0, WOLFCLU_NOOUT     },
-    {"help",      no_argument,       0, WOLFCLU_HELP      },
-    {"h",         no_argument,       0, WOLFCLU_HELP      },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE    },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE   },
+    {"-inform",    required_argument, 0, WOLFCLU_INFORM    },
+    {"-outform",   required_argument, 0, WOLFCLU_OUTFORM   },
+    {"-CAfile",    required_argument, 0, WOLFCLU_CAFILE    },
+    {"-noout",     no_argument,       0, WOLFCLU_NOOUT     },
+    {"-help",      no_argument,       0, WOLFCLU_HELP      },
+    {"-h",         no_argument,       0, WOLFCLU_HELP      },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -74,7 +74,7 @@ int wolfCLU_CRLVerify(int argc, char** argv)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "", crl_options,
+    while ((option = wolfCLU_GetOpt(argc, argv, "", crl_options,
                     &longIndex )) != -1) {
         switch (option) {
             case WOLFCLU_OUTFILE:

--- a/src/sign-verify/clu_dgst_setup.c
+++ b/src/sign-verify/clu_dgst_setup.c
@@ -29,19 +29,19 @@
 
 static const struct option dgst_options[] = {
 
-    {"md5",       no_argument,       0, WOLFCLU_MD5        },
-    {"sha",       no_argument,       0, WOLFCLU_CERT_SHA   },
-    {"sha224",    no_argument,       0, WOLFCLU_CERT_SHA224},
-    {"sha256",    no_argument,       0, WOLFCLU_CERT_SHA256},
-    {"sha384",    no_argument,       0, WOLFCLU_CERT_SHA384},
-    {"sha512",    no_argument,       0, WOLFCLU_CERT_SHA512},
+    {"-md5",       no_argument,       0, WOLFCLU_MD5        },
+    {"-sha",       no_argument,       0, WOLFCLU_CERT_SHA   },
+    {"-sha224",    no_argument,       0, WOLFCLU_CERT_SHA224},
+    {"-sha256",    no_argument,       0, WOLFCLU_CERT_SHA256},
+    {"-sha384",    no_argument,       0, WOLFCLU_CERT_SHA384},
+    {"-sha512",    no_argument,       0, WOLFCLU_CERT_SHA512},
 
-    {"out",       required_argument, 0, WOLFCLU_INFILE    },
-    {"signature", required_argument, 0, WOLFCLU_INFILE    },
-    {"verify",    required_argument, 0, WOLFCLU_VERIFY    },
-    {"sign",     required_argument, 0, WOLFCLU_SIGN      },
-    {"h",        no_argument,       0, WOLFCLU_HELP      },
-    {"help",     no_argument,       0, WOLFCLU_HELP      },
+    {"-out",       required_argument, 0, WOLFCLU_INFILE    },
+    {"-signature", required_argument, 0, WOLFCLU_INFILE    },
+    {"-verify",    required_argument, 0, WOLFCLU_VERIFY    },
+    {"-sign",     required_argument, 0, WOLFCLU_SIGN      },
+    {"-h",        no_argument,       0, WOLFCLU_HELP      },
+    {"-help",     no_argument,       0, WOLFCLU_HELP      },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -192,7 +192,7 @@ int wolfCLU_dgst_setup(int argc, char** argv)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "",
+    while ((option = wolfCLU_GetOpt(argc, argv, "",
                    dgst_options, &longIndex )) != -1) {
 
         switch (option) {

--- a/src/sign-verify/clu_sign_verify_setup.c
+++ b/src/sign-verify/clu_sign_verify_setup.c
@@ -39,13 +39,15 @@ int wolfCLU_sign_verify_setup(int argc, char** argv)
     int     verifyCheck = 0;
     int     pubInCheck  = 0;
 
-    if (wolfCLU_checkForArg("-rsa", 4, argc, argv) > 0) {
+    /* checkForArg doesn't look for "-" here, as it would have been 
+     * removed in clu_main.c if present */
+    if (wolfCLU_checkForArg("rsa", 3, argc, argv) > 0) {
         algCheck = RSA_SIG_VER;
     }
-    else if (wolfCLU_checkForArg("-ed25519", 8, argc, argv) > 0) {
+    else if (wolfCLU_checkForArg("ed25519", 7, argc, argv) > 0) {
         algCheck = ED25519_SIG_VER;
     }
-    else if (wolfCLU_checkForArg("-ecc", 4, argc, argv) > 0) {
+    else if (wolfCLU_checkForArg("ecc", 3, argc, argv) > 0) {
         algCheck = ECC_SIG_VER;
     }
     else {

--- a/src/sign-verify/clu_x509_verify.c
+++ b/src/sign-verify/clu_x509_verify.c
@@ -26,10 +26,10 @@
 #include <wolfclu/x509/clu_cert.h>
 
 static const struct option verify_options[] = {
-    {"CAfile",    required_argument, 0, WOLFCLU_CAFILE    },
-    {"crl_check", no_argument,       0, WOLFCLU_CHECK_CRL },
-    {"help",      no_argument,       0, WOLFCLU_HELP      },
-    {"h",         no_argument,       0, WOLFCLU_HELP      },
+    {"-CAfile",    required_argument, 0, WOLFCLU_CAFILE    },
+    {"-crl_check", no_argument,       0, WOLFCLU_CHECK_CRL },
+    {"-help",      no_argument,       0, WOLFCLU_HELP      },
+    {"-h",         no_argument,       0, WOLFCLU_HELP      },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -73,7 +73,7 @@ int wolfCLU_x509Verify(int argc, char** argv)
 
         opterr = 0; /* do not display unrecognized options */
         optind = 0; /* start at indent 0 */
-        while ((option = getopt_long_only(argc - 1, argv, "",
+        while ((option = wolfCLU_GetOpt(argc - 1, argv, "",
                        verify_options, &longIndex )) != -1) {
             switch (option) {
                 case WOLFCLU_CHECK_CRL:

--- a/src/tools/clu_hex_to_bin.c
+++ b/src/tools/clu_hex_to_bin.c
@@ -20,7 +20,9 @@
  */
 #include <stdio.h>
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/coding.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>

--- a/src/tools/clu_rand.c
+++ b/src/tools/clu_rand.c
@@ -24,8 +24,8 @@
 #include <wolfclu/clu_optargs.h>
 
 static const struct option rand_options[] = {
-    {"out",    required_argument, 0, WOLFCLU_OUTFILE},
-    {"base64", no_argument,       0, WOLFCLU_BASE64 },
+    {"-out",    required_argument, 0, WOLFCLU_OUTFILE},
+    {"-base64", no_argument,       0, WOLFCLU_BASE64 },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -65,7 +65,7 @@ int wolfCLU_Rand(int argc, char** argv)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "",
+    while ((option = wolfCLU_GetOpt(argc, argv, "",
                    rand_options, &longIndex )) != -1) {
         switch (option) {
             case WOLFCLU_BASE64:

--- a/src/x509/clu_ca_setup.c
+++ b/src/x509/clu_ca_setup.c
@@ -28,18 +28,18 @@
 #include <wolfclu/certgen/clu_certgen.h>
 
 static const struct option ca_options[] = {
-    {"in",        required_argument, 0, WOLFCLU_INFILE    },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE   },
-    {"keyfile",   required_argument, 0, WOLFCLU_KEY       },
-    {"cert",      required_argument, 0, WOLFCLU_CAFILE    },
-    {"extensions",required_argument, 0, WOLFCLU_EXTENSIONS},
-    {"md",        required_argument, 0, WOLFCLU_MD        },
-    {"inform",    required_argument, 0, WOLFCLU_INFORM    },
-    {"config",    required_argument, 0, WOLFCLU_CONFIG },
-    {"days",      required_argument, 0, WOLFCLU_DAYS },
-    {"selfsign",  no_argument, 0, WOLFCLU_SELFSIGN },
-    {"h",         no_argument, 0, WOLFCLU_HELP },
-    {"help",      no_argument, 0, WOLFCLU_HELP },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE    },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE   },
+    {"-keyfile",   required_argument, 0, WOLFCLU_KEY       },
+    {"-cert",      required_argument, 0, WOLFCLU_CAFILE    },
+    {"-extensions",required_argument, 0, WOLFCLU_EXTENSIONS},
+    {"-md",        required_argument, 0, WOLFCLU_MD        },
+    {"-inform",    required_argument, 0, WOLFCLU_INFORM    },
+    {"-config",    required_argument, 0, WOLFCLU_CONFIG },
+    {"-days",      required_argument, 0, WOLFCLU_DAYS },
+    {"-selfsign",  no_argument, 0, WOLFCLU_SELFSIGN },
+    {"-h",         no_argument, 0, WOLFCLU_HELP },
+    {"-help",      no_argument, 0, WOLFCLU_HELP },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -83,7 +83,7 @@ int wolfCLU_CASetup(int argc, char** argv)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "", ca_options,
+    while ((option = wolfCLU_GetOpt(argc, argv, "", ca_options,
                     &longIndex )) != -1) {
 
         switch (option) {

--- a/src/x509/clu_cert_setup.c
+++ b/src/x509/clu_cert_setup.c
@@ -20,7 +20,6 @@
  */
 
 #include <stdio.h>
-#include <unistd.h>
 
 #include <wolfclu/clu_header_main.h>
 #include <wolfclu/clu_log.h>

--- a/src/x509/clu_request_setup.c
+++ b/src/x509/clu_request_setup.c
@@ -30,34 +30,34 @@
 #ifdef WOLFSSL_CERT_REQ
 static const struct option req_options[] = {
 
-    {"sha",       no_argument,       0, WOLFCLU_CERT_SHA   },
-    {"sha224",    no_argument,       0, WOLFCLU_CERT_SHA224},
-    {"sha256",    no_argument,       0, WOLFCLU_CERT_SHA256},
-    {"sha384",    no_argument,       0, WOLFCLU_CERT_SHA384},
-    {"sha512",    no_argument,       0, WOLFCLU_CERT_SHA512},
-    {"rsa",       no_argument,       0, WOLFCLU_RSA       },
-    {"ed25519",   no_argument,       0, WOLFCLU_ED25519   },
+    {"-sha",       no_argument,       0, WOLFCLU_CERT_SHA   },
+    {"-sha224",    no_argument,       0, WOLFCLU_CERT_SHA224},
+    {"-sha256",    no_argument,       0, WOLFCLU_CERT_SHA256},
+    {"-sha384",    no_argument,       0, WOLFCLU_CERT_SHA384},
+    {"-sha512",    no_argument,       0, WOLFCLU_CERT_SHA512},
+    {"-rsa",       no_argument,       0, WOLFCLU_RSA       },
+    {"-ed25519",   no_argument,       0, WOLFCLU_ED25519   },
 
-    {"in",        required_argument, 0, WOLFCLU_INFILE    },
-    {"out",       required_argument, 0, WOLFCLU_OUTFILE   },
-    {"key",       required_argument, 0, WOLFCLU_KEY       },
-    {"new",       no_argument,       0, WOLFCLU_NEW       },
-    {"newkey",    required_argument, 0, WOLFCLU_NEWKEY },
-    {"inkey",     required_argument, 0, WOLFCLU_INKEY     },
-    {"keyout",    required_argument, 0, WOLFCLU_OUTKEY     },
-    {"inform",    required_argument, 0, WOLFCLU_INFORM    },
-    {"outform",   required_argument, 0, WOLFCLU_OUTFORM   },
-    {"config",    required_argument, 0, WOLFCLU_CONFIG },
-    {"days",      required_argument, 0, WOLFCLU_DAYS },
-    {"x509",      no_argument,       0, WOLFCLU_X509 },
-    {"subj",      required_argument, 0, WOLFCLU_SUBJECT },
-    {"verify",    no_argument,       0, WOLFCLU_VERIFY },
-    {"text",      no_argument,       0, WOLFCLU_TEXT_OUT },
-    {"noout",     no_argument,       0, WOLFCLU_NOOUT },
-    {"extensions",required_argument, 0, WOLFCLU_EXTENSIONS},
-    {"nodes",     no_argument,       0, WOLFCLU_NODES },
-    {"h",         no_argument,       0, WOLFCLU_HELP },
-    {"help",      no_argument,       0, WOLFCLU_HELP },
+    {"-in",        required_argument, 0, WOLFCLU_INFILE    },
+    {"-out",       required_argument, 0, WOLFCLU_OUTFILE   },
+    {"-key",       required_argument, 0, WOLFCLU_KEY       },
+    {"-new",       no_argument,       0, WOLFCLU_NEW       },
+    {"-newkey",    required_argument, 0, WOLFCLU_NEWKEY },
+    {"-inkey",     required_argument, 0, WOLFCLU_INKEY     },
+    {"-keyout",    required_argument, 0, WOLFCLU_OUTKEY     },
+    {"-inform",    required_argument, 0, WOLFCLU_INFORM    },
+    {"-outform",   required_argument, 0, WOLFCLU_OUTFORM   },
+    {"-config",    required_argument, 0, WOLFCLU_CONFIG },
+    {"-days",      required_argument, 0, WOLFCLU_DAYS },
+    {"-x509",      no_argument,       0, WOLFCLU_X509 },
+    {"-subj",      required_argument, 0, WOLFCLU_SUBJECT },
+    {"-verify",    no_argument,       0, WOLFCLU_VERIFY },
+    {"-text",      no_argument,       0, WOLFCLU_TEXT_OUT },
+    {"-noout",     no_argument,       0, WOLFCLU_NOOUT },
+    {"-extensions",required_argument, 0, WOLFCLU_EXTENSIONS},
+    {"-nodes",     no_argument,       0, WOLFCLU_NODES },
+    {"-h",         no_argument,       0, WOLFCLU_HELP },
+    {"-help",      no_argument,       0, WOLFCLU_HELP },
 
     {0, 0, 0, 0} /* terminal element */
 };
@@ -525,7 +525,7 @@ int wolfCLU_requestSetup(int argc, char** argv)
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
-    while ((option = getopt_long_only(argc, argv, "", req_options,
+    while ((option = wolfCLU_GetOpt(argc, argv, "", req_options,
                     &longIndex )) != -1) {
 
         switch (option) {

--- a/tests/encrypt/enc-test.sh
+++ b/tests/encrypt/enc-test.sh
@@ -55,8 +55,8 @@ fi
 rm -f test-dec.der
 rm -f test-enc.der
 
-run "enc -aes-128-cbc -in ./configure.ac -out ./configure.ac.enc -k 'test'"
-run "enc -d -aes-128-cbc -in ./configure.ac.enc -out ./configure.ac.dec -k 'test'"
+run "enc -aes-128-cbc -in ./configure.ac -out ./configure.ac.enc" "test"
+run "enc -d -aes-128-cbc -in ./configure.ac.enc -out ./configure.ac.dec" "test"
 diff ./configure.ac ./configure.ac.dec
 if [ $? != 0 ]; then
     echo "decrypted file does not match original file"
@@ -68,8 +68,8 @@ rm -f configure.ac.enc
 # small file test
 rm -rf enc_small.txt
 echo " " > enc_small.txt
-run "enc -aes-128-cbc -in ./enc_small.txt -out ./enc_small.txt.enc -k 'test'"
-run "enc -d -aes-128-cbc -in ./enc_small.txt.enc -out ./enc_small.txt.dec -k 'test'"
+run "enc -aes-128-cbc -in ./enc_small.txt -out ./enc_small.txt.enc 'test'"
+run "enc -d -aes-128-cbc -in ./enc_small.txt.enc -out ./enc_small.txt.dec 'test'"
 diff ./enc_small.txt ./enc_small.txt.dec
 if [ $? != 0 ]; then
     echo "enc_small decrypted file does not match original file"

--- a/wolfCLU.vcxproj
+++ b/wolfCLU.vcxproj
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{CFC6FB69-7DA4-4E35-851E-776010E92FB3}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>wolfssl</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>wolfssl</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>wolfssl</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>wolfssl</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WOLFCLU_EXPORTS;WOLFSSL_LIB;_WINDLL;WOLFSSL_USER_SETTINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);.;./../wolfssl/;../wolfssl/IDE/WIN;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>Ws2_32.lib;wolfssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../wolfssl/Debug/Win32;../wolfssl/Release/Win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WOLFCLU_EXPORTS;WOLFSSL_LIB;_WINDLL;WOLFSSL_USER_SETTINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);.;./../wolfssl/;../wolfssl/IDE/WIN;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Ws2_32.lib;wolfssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../wolfssl/Debug/Win32;../wolfssl/Release/Win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ProjectDir);.;./../wolfssl/;../wolfssl/IDE/WIN;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WOLFCLU_EXPORTS;WOLFSSL_LIB;_WINDLL;WOLFSSL_USER_SETTINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Ws2_32.lib;wolfssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../wolfssl/Debug/x64;../wolfssl/Release/x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ProjectDir);.;./../wolfssl/;../wolfssl/IDE/WIN;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WOLFCLU_EXPORTS;WOLFSSL_LIB;_WINDLL;WOLFSSL_USER_SETTINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Ws2_32.lib;wolfssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../wolfssl/Debug/x64;../wolfssl/Release/x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="src\benchmark\clu_benchmark.c" />
+    <ClCompile Include="src\benchmark\clu_bench_setup.c" />
+    <ClCompile Include="src\certgen\clu_certgen_ed25519.c" />
+    <ClCompile Include="src\certgen\clu_certgen_rsa.c" />
+    <ClCompile Include="src\client\client.c" />
+    <ClCompile Include="src\client\clu_client_setup.c" />
+    <ClCompile Include="src\clu_log.c" />
+    <ClCompile Include="src\clu_main.c" />
+    <ClCompile Include="src\crypto\clu_crypto_setup.c" />
+    <ClCompile Include="src\crypto\clu_decrypt.c" />
+    <ClCompile Include="src\crypto\clu_encrypt.c" />
+    <ClCompile Include="src\crypto\clu_evp_crypto.c" />
+    <ClCompile Include="src\dh\clu_dh.c" />
+    <ClCompile Include="src\dsa\clu_dsa.c" />
+    <ClCompile Include="src\ecparam\clu_ecparam.c" />
+    <ClCompile Include="src\genkey\clu_genkey.c" />
+    <ClCompile Include="src\genkey\clu_genkey_setup.c" />
+    <ClCompile Include="src\hash\clu_hash.c" />
+    <ClCompile Include="src\hash\clu_hash_setup.c" />
+    <ClCompile Include="src\hash\clu_alg_hash.c" />
+    <ClCompile Include="src\pkcs\clu_pkcs12.c" />
+    <ClCompile Include="src\pkey\clu_pkey.c" />
+    <ClCompile Include="src\pkey\clu_rsa.c" />
+    <ClCompile Include="src\sign-verify\clu_crl_verify.c" />
+    <ClCompile Include="src\sign-verify\clu_dgst_setup.c" />
+    <ClCompile Include="src\sign-verify\clu_sign.c" />
+    <ClCompile Include="src\sign-verify\clu_sign_verify_setup.c" />
+    <ClCompile Include="src\sign-verify\clu_verify.c" />
+    <ClCompile Include="src\sign-verify\clu_x509_verify.c" />
+    <ClCompile Include="src\tools\clu_funcs.c" />
+    <ClCompile Include="src\tools\clu_hex_to_bin.c" />
+    <ClCompile Include="src\tools\clu_rand.c" />
+    <ClCompile Include="src\x509\clu_ca_setup.c" />
+    <ClCompile Include="src\x509\clu_cert_setup.c" />
+    <ClCompile Include="src\x509\clu_config.c" />
+    <ClCompile Include="src\x509\clu_parse.c" />
+    <ClCompile Include="src\x509\clu_request_setup.c" />
+    <ClCompile Include="src\x509\clu_x509_sign.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\wolfssl\IDE\WIN\USER_SETTINGS.H" />
+    <ClInclude Include="wolfclu\certgen\clu_certgen.h" />
+    <ClInclude Include="wolfclu\client.h" />
+    <ClInclude Include="wolfclu\clu_error_codes.h" />
+    <ClInclude Include="wolfclu\clu_header_main.h" />
+    <ClInclude Include="wolfclu\clu_log.h" />
+    <ClInclude Include="wolfclu\clu_optargs.h" />
+    <ClInclude Include="wolfclu\genkey\clu_genkey.h" />
+    <ClInclude Include="wolfclu\pkey\clu_pkey.h" />
+    <ClInclude Include="wolfclu\sign-verify\clu_sign.h" />
+    <ClInclude Include="wolfclu\sign-verify\clu_sign_verify_setup.h" />
+    <ClInclude Include="wolfclu\sign-verify\clu_verify.h" />
+    <ClInclude Include="wolfclu\version.h" />
+    <ClInclude Include="wolfclu\x509\clu_cert.h" />
+    <ClInclude Include="wolfclu\x509\clu_parse.h" />
+    <ClInclude Include="wolfclu\x509\clu_request.h" />
+    <ClInclude Include="wolfclu\x509\clu_x509_sign.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/wolfCLU.vcxproj.filters
+++ b/wolfCLU.vcxproj.filters
@@ -1,0 +1,186 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\clu_log.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\clu_main.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\benchmark\clu_benchmark.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\benchmark\clu_bench_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\certgen\clu_certgen_ed25519.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\certgen\clu_certgen_rsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\client\client.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\client\clu_client_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\crypto\clu_crypto_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\crypto\clu_decrypt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\crypto\clu_encrypt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\crypto\clu_evp_crypto.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\dh\clu_dh.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\dsa\clu_dsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ecparam\clu_ecparam.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\genkey\clu_genkey.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\genkey\clu_genkey_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hash\clu_hash.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hash\clu_hash_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hash\clu_alg_hash.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\pkcs\clu_pkcs12.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\pkey\clu_pkey.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\pkey\clu_rsa.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sign-verify\clu_crl_verify.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sign-verify\clu_dgst_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sign-verify\clu_sign.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sign-verify\clu_sign_verify_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sign-verify\clu_verify.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sign-verify\clu_x509_verify.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\tools\clu_funcs.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\tools\clu_hex_to_bin.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\tools\clu_rand.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\x509\clu_ca_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\x509\clu_cert_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\x509\clu_config.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\x509\clu_parse.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\x509\clu_request_setup.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\x509\clu_x509_sign.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="wolfclu\client.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\clu_error_codes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\clu_header_main.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\clu_log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\clu_optargs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\certgen\clu_certgen.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\genkey\clu_genkey.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\pkey\clu_pkey.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\sign-verify\clu_sign.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\sign-verify\clu_sign_verify_setup.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\sign-verify\clu_verify.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\x509\clu_cert.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\x509\clu_parse.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\x509\clu_request.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wolfclu\x509\clu_x509_sign.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wolfssl\IDE\WIN\USER_SETTINGS.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/wolfclu.sln
+++ b/wolfclu.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wolfCLU", "wolfCLU.vcxproj", "{CFC6FB69-7DA4-4E35-851E-776010E92FB3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Debug|Win32.ActiveCfg = Debug|Win32
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Debug|Win32.Build.0 = Debug|Win32
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Debug|x64.ActiveCfg = Debug|Win32
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Debug|x64.Build.0 = Debug|Win32
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Debug|x86.ActiveCfg = Debug|Win32
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Debug|x86.Build.0 = Debug|Win32
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Release|Win32.ActiveCfg = Release|Win32
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Release|Win32.Build.0 = Release|Win32
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Release|x64.ActiveCfg = Release|x64
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Release|x64.Build.0 = Release|x64
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Release|x86.ActiveCfg = Release|Win32
+		{CFC6FB69-7DA4-4E35-851E-776010E92FB3}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {53F3FB1B-2B72-4D13-A43B-BBD80FCAADA9}
+	EndGlobalSection
+EndGlobal

--- a/wolfclu/certgen/clu_certgen.h
+++ b/wolfclu/certgen/clu_certgen.h
@@ -1,5 +1,7 @@
 #include <stdio.h>
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/asn_public.h>

--- a/wolfclu/client.h
+++ b/wolfclu/client.h
@@ -24,7 +24,6 @@
 #define WOLFSSL_CLIENT_H
 
 #define NO_MAIN_DRIVER
-typedef void* THREAD_RETURN;
 #define WOLFSSL_THREAD
 
 THREAD_RETURN WOLFSSL_THREAD client_test(void* args);

--- a/wolfclu/clu_header_main.h
+++ b/wolfclu/clu_header_main.h
@@ -22,16 +22,29 @@
 #ifndef _WOLFSSL_CLU_HEADER_
 #define _WOLFSSL_CLU_HEADER_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <string.h>
 #include <stdio.h>
-#include <signal.h>
+
+#ifdef _WIN32 /* running on windows */
+#include <winsock2.h>
+#include <windows.h>
+#include <corecrt_io.h>
+#include <sys/timeb.h>
+
+#else /* running on *nix */
 #include <unistd.h>
 #include <termios.h>
 #include <sys/time.h>
-#include <getopt.h>
+#endif
 
 /* wolfssl includes */
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #include <wolfssl/error-ssl.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/version.h>
@@ -113,6 +126,33 @@
   * or code update
   */
 #define VERSION 0.3
+
+/**
+ * @brief structs and variables to parse commands
+ */
+struct option
+{
+    const char *name;
+    int has_arg;
+    int *flag;
+    int val;
+};
+
+#define required_argument 1
+#define no_argument       0
+
+/* define macros, functions, and data types for windows */
+#ifdef _WIN32
+
+#define int64_t long long
+#define access _access
+#define F_OK 00
+#define strtok_r strtok_s
+
+extern char* optarg;
+extern int   optind ;
+extern int   opterr ;
+#endif
 
 /* encryption argument function
  *
@@ -367,6 +407,16 @@ int wolfCLU_algHashSetup(int argc, char** argv, int algorithm);
  */
 int wolfCLU_version(void);
 
+/**
+ * @brief Used to check for specified command
+ */
+int wolfCLU_GetOpt(int argc, char** argv, const char *options, const struct option *long_options, int *opt_index);
+
+/**
+ * @brief wolfCLU getline() implementation
+ */
+size_t wolfCLU_getline(char **line, size_t *len, FILE *fp);
+
 /*
  * generic function to check for a specific input argument. Return the
  * argv[i] where argument was found. Useful for getting following value after
@@ -507,4 +557,9 @@ int wolfCLU_DhParamSetup(int argc, char** argv);
  * @brief function to prompt user for password from stdin
  */
 int wolfCLU_GetStdinPassword(byte* password, word32* passwordSz);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _WOLFSSL_CLU_HEADER_ */

--- a/wolfclu/genkey/clu_genkey.h
+++ b/wolfclu/genkey/clu_genkey.h
@@ -22,7 +22,9 @@
 #ifndef CLU_GENKEY_H
 #define CLU_GENKEY_H
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #ifdef HAVE_ED25519
     #include <wolfssl/wolfcrypt/ed25519.h>
 #endif

--- a/wolfclu/pkey/clu_pkey.h
+++ b/wolfclu/pkey/clu_pkey.h
@@ -22,7 +22,9 @@
 #ifndef CLU_PKEY_H
 #define CLU_PKEY_H
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #ifdef HAVE_ED25519
     #include <wolfssl/wolfcrypt/ed25519.h>
 #endif

--- a/wolfclu/sign-verify/clu_sign.h
+++ b/wolfclu/sign-verify/clu_sign.h
@@ -19,7 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #ifdef HAVE_ED25519
     #include <wolfssl/wolfcrypt/ed25519.h>
 #endif

--- a/wolfclu/sign-verify/clu_verify.h
+++ b/wolfclu/sign-verify/clu_verify.h
@@ -19,7 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#endif
 #ifdef HAVE_ED25519
     #include <wolfssl/wolfcrypt/ed25519.h>
 #endif


### PR DESCRIPTION
- Adding `wolfCLU_GetOpt` to be used instead of `getopt_long_only`
- Adding `wolfCLU_getline` to be used instead of `getline`
- Changes to `clu_header_main.h` for windows compatability
- Adding wolfCLU `.sln` and `.vcxproj` project files, documentation, as well as the wolfssl settings needed to build the solution.
- Adding windows github action test