### PR TITLE
Add support for s_client flags -CAfile and -verify_return_error.

### DIFF
--- a/wolfclu/clu_optargs.h
+++ b/wolfclu/clu_optargs.h
@@ -95,7 +95,7 @@ enum {
     WOLFCLU_HELP,
     WOLFCLU_DEBUG,
     WOLFCLU_CHECK,
-
+    WOLFCLU_VERIFY_RETURN_ERROR,
 };
 
 /* algos */


### PR DESCRIPTION
Tested locally using wolfSSL example certs. We should add a test script for s_client eventually, though.