### PR TITLE
Adding -text arg for crl command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,9 @@ AC_CHECK_LIB([wolfssl],[wolfCrypt_Init],,[AC_MSG_ERROR([libwolfssl is required a
 AM_CFLAGS="$AM_CFLAGS -DHAVE_WOLFSSL_OPTIONS"
 
 # check for some conditional functions
+AC_CHECK_FUNC([wolfSSL_X509_CRL_print],
+    [],
+    [AM_CFLAGS="$AM_CFLAGS -DNO_WOLFSSL_CRL_PRINT"])
 AC_CHECK_FUNC([wolfSSL_X509_REQ_print],
     [],
     [AM_CFLAGS="$AM_CFLAGS -DNO_WOLFSSL_REQ_PRINT"])

--- a/src/sign-verify/clu_crl_verify.c
+++ b/src/sign-verify/clu_crl_verify.c
@@ -52,7 +52,8 @@ static void wolfCLU_CRLVerifyHelp(void)
             "-outform pem or der out format");
     WOLFCLU_LOG(WOLFCLU_L0,
             "-out output file to write to\n"
-            "-noout do not print output if set");
+            "-noout do not print output if set\n"
+            "-text output human readable text of CRL");
 }
 #endif
 
@@ -219,6 +220,7 @@ int wolfCLU_CRLVerify(int argc, char** argv)
     }
 
     if (ret == WOLFCLU_SUCCESS && text != 0) {
+    #ifndef NO_WOLFSSL_CRL_PRINT
         /* set to stdout if no output is set */
         if (bioOut == NULL) {
             bioOut = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
@@ -233,6 +235,10 @@ int wolfCLU_CRLVerify(int argc, char** argv)
             }
         }
         wolfSSL_X509_CRL_print(bioOut, test);
+    #else
+        wolfCLU_LogError("CRL print not available in version of wolfSSL");
+        ret = WOLFCLU_FATAL_ERROR;
+    #endif
     }
 
     if (ret == WOLFCLU_SUCCESS && output != 0) {

--- a/src/sign-verify/clu_crl_verify.c
+++ b/src/sign-verify/clu_crl_verify.c
@@ -33,6 +33,7 @@ static const struct option crl_options[] = {
     {"-inform",    required_argument, 0, WOLFCLU_INFORM    },
     {"-outform",   required_argument, 0, WOLFCLU_OUTFORM   },
     {"-CAfile",    required_argument, 0, WOLFCLU_CAFILE    },
+    {"-text",      no_argument,       0, WOLFCLU_TEXT_OUT  },
     {"-noout",     no_argument,       0, WOLFCLU_NOOUT     },
     {"-help",      no_argument,       0, WOLFCLU_HELP      },
     {"-h",         no_argument,       0, WOLFCLU_HELP      },
@@ -63,6 +64,7 @@ int wolfCLU_CRLVerify(int argc, char** argv)
     int inForm  = PEM_FORM;
     int outForm = PEM_FORM;
     int output = 1;
+    int text   = 0;
     int longIndex = 1;
     int option;
     byte* der   = NULL;
@@ -71,6 +73,7 @@ int wolfCLU_CRLVerify(int argc, char** argv)
     char* out = NULL;
     WOLFSSL_BIO* bioIn  = NULL;
     WOLFSSL_BIO* bioOut = NULL;
+    WOLFSSL_X509_CRL* test;
 
     opterr = 0; /* do not display unrecognized options */
     optind = 0; /* start at indent 0 */
@@ -100,6 +103,10 @@ int wolfCLU_CRLVerify(int argc, char** argv)
 
             case WOLFCLU_CAFILE:
                 caCert = optarg;
+                break;
+
+            case WOLFCLU_TEXT_OUT:
+                text = 1;
                 break;
 
             case WOLFCLU_NOOUT:
@@ -175,17 +182,12 @@ int wolfCLU_CRLVerify(int argc, char** argv)
         }
     }
 
+    test = wolfSSL_d2i_X509_CRL(NULL, der, derSz);
     /* sanity check that input is indeed a CRL */
     if (ret == WOLFCLU_SUCCESS) {
-        WOLFSSL_X509_CRL* test;
-
-        test = wolfSSL_d2i_X509_CRL(NULL, der, derSz);
         if (test == NULL) {
             wolfCLU_LogError("Unable to parse CRL file");
             ret = WOLFCLU_FATAL_ERROR;
-        }
-        else {
-            wolfSSL_X509_CRL_free(test);
         }
     }
 
@@ -214,6 +216,23 @@ int wolfCLU_CRLVerify(int argc, char** argv)
                 }
             }
         }
+    }
+
+    if (ret == WOLFCLU_SUCCESS && text != 0) {
+        /* set to stdout if no output is set */
+        if (bioOut == NULL) {
+            bioOut = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
+            if (bioOut == NULL) {
+                ret = WOLFCLU_FATAL_ERROR;
+            }
+            else {
+                if (wolfSSL_BIO_set_fp(bioOut, stdout, BIO_NOCLOSE)
+                        != WOLFSSL_SUCCESS) {
+                    ret = WOLFCLU_FATAL_ERROR;
+                }
+            }
+        }
+        wolfSSL_X509_CRL_print(bioOut, test);
     }
 
     if (ret == WOLFCLU_SUCCESS && output != 0) {
@@ -263,6 +282,7 @@ int wolfCLU_CRLVerify(int argc, char** argv)
     if (der != NULL) {
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_CRL);
     }
+    wolfSSL_X509_CRL_free(test);
     wolfSSL_BIO_free(bioIn);
     wolfSSL_BIO_free(bioOut);
     return ret;

--- a/tests/x509/CRL-verify-test.sh
+++ b/tests/x509/CRL-verify-test.sh
@@ -74,6 +74,15 @@ if [ -f "test.crl.pem" ]; then
     exit 99
 fi
 
+# check the CRL -text arg
+run_success "crl -noout -in ./certs/crl.pem -text"
+echo $RESULT | grep "Certificate Revocation List (CRL):"
+if [ $? != 0 ]; then
+    echo $RESULT
+    echo "Couldn't find expected output"
+    exit 99
+fi
+
 echo "Done"
 exit 0
 

--- a/tests/x509/CRL-verify-test.sh
+++ b/tests/x509/CRL-verify-test.sh
@@ -74,13 +74,17 @@ if [ -f "test.crl.pem" ]; then
     exit 99
 fi
 
-# check the CRL -text arg
-run_success "crl -noout -in ./certs/crl.pem -text"
-echo $RESULT | grep "Certificate Revocation List (CRL):"
-if [ $? != 0 ]; then
-    echo $RESULT
-    echo "Couldn't find expected output"
-    exit 99
+RESULT=`./wolfssl crl -in certs/crl.pem -text`
+echo $RESULT | grep "CRL print not available in version of wolfSSL"
+if [ $? == 0 ]; then
+    # check the CRL -text arg
+    run_success "crl -noout -in ./certs/crl.pem -text"
+    echo $RESULT | grep "Certificate Revocation List (CRL):"
+    if [ $? != 0 ]; then
+        echo $RESULT
+        echo "Couldn't find expected output"
+        exit 99
+    fi
 fi
 
 echo "Done"


### PR DESCRIPTION
```
lealem@ubuntu:~/HOME/wolfCLU$ ./wolfssl crl -in crl.pem -text -noout
Certificate Revocation List (CRL):
        Version: 2 (0x1)
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com, emailAddress=info@wolfssl.com
        Last Update: Dec 20 23:07:25 2021 GMT
        Next Update: Sep 15 23:07:25 2024 GMT
        CRL extensions:
            X509v3 CRL Number:
                2
Revoked Certificates:
    Serial Number: 2 (0x2)
        Revocation Date: Dec 20 23:07:25 2021 GMT
    Signature Algorithm: sha256WithRSAEncryption
         8b:c0:b8:cb:03:5c:8c:d1:53:b2:c5:b1:4d:f3:b3:e8:13:bf:
         5f:a7:1a:cc:74:e8:06:66:c1:cb:89:c3:e3:b3:fb:68:4e:8f:
         d0:5b:33:d8:ed:5e:14:b3:21:c8:c0:06:66:97:6d:69:96:78:
         bd:a9:d1:59:85:0f:13:29:2d:2f:49:87:94:84:14:94:38:74:
         04:16:94:10:ea:f2:31:d8:34:b7:65:e8:5e:52:4f:96:ac:bf:
         5f:4f:6c:ee:5d:04:2a:26:b2:29:7c:9d:06:82:b3:b5:e6:5b:
         d5:11:72:56:d5:34:75:82:5e:2a:f3:c6:67:72:94:c6:02:83:
         e8:58:85:2d:73:db:55:30:a2:c2:b1:bb:4c:bf:f6:a2:d8:b3:
         fc:1b:bd:51:97:4e:f4:c2:04:4f:04:ee:61:e7:51:4b:4f:09:
         fe:10:5c:3c:1e:e0:cb:51:1f:54:f4:38:3f:6c:58:ee:4e:f8:
         ca:34:cd:37:ee:bb:06:53:14:c7:60:a4:89:ac:9a:50:4a:b5:
         9e:b3:59:97:9b:27:5e:5c:fa:14:74:3d:a2:76:62:63:ae:e8:
         d2:f9:b7:ad:0c:3f:07:40:50:5c:e4:fb:95:3c:3d:df:2e:81:
         f2:6a:9e:01:69:c3:a2:1e:d7:00:2b:6d:6c:67:f0:fb:13:ce:
         f1:a5:08:d6
```

Won't pass tests until https://github.com/wolfSSL/wolfssl/pull/5388 is merged.