### PR TITLE
fix up subject print expected for test with latest wolfSSL version

### DIFF
--- a/src/x509/clu_request_setup.c
+++ b/src/x509/clu_request_setup.c
@@ -864,8 +864,10 @@ int wolfCLU_requestSetup(int argc, char** argv)
         }
     }
 
-    /* default to CA:TRUE for req -x509 command */
-    if (ret == WOLFCLU_SUCCESS && !wolfSSL_X509_ext_isSet_by_NID(x509, NID_basic_constraints)) {
+    /* default to CA:TRUE for req -x509 command (self signed certificates) when
+     * a basic constraint is not already set */
+    if (genX509 && ret == WOLFCLU_SUCCESS &&
+            !wolfSSL_X509_ext_isSet_by_NID(x509, NID_basic_constraints)) {
         WOLFSSL_X509_EXTENSION *newExt;
         WOLFSSL_ASN1_OBJECT *obj;
 
@@ -880,7 +882,8 @@ int wolfCLU_requestSetup(int argc, char** argv)
 
             ret = wolfSSL_X509_add_ext(x509, newExt, -1);
             if (ret != WOLFSSL_SUCCESS) {
-                WOLFCLU_LOG(WOLFCLU_E0, "error %d adding Basic Constraints extesion", ret);
+                WOLFCLU_LOG(WOLFCLU_E0,
+                        "error %d adding Basic Constraints extesion", ret);
             }
             wolfSSL_X509_EXTENSION_free(newExt);
         }

--- a/tests/x509/x509-req-test.sh
+++ b/tests/x509/x509-req-test.sh
@@ -99,9 +99,12 @@ EOF
 run_success "req -new -days 3650 -key ./certs/server-key.pem -subj O=wolfSSL/C=US/ST=WA/L=Seattle/CN=wolfSSL/OU=org-unit -out tmp.cert -x509"
 
 SUBJECT=`./wolfssl x509 -in tmp.cert -text | grep Subject:`
-if [ "$SUBJECT" != "        Subject: O=wolfSSL, C=US, ST=WA, L=Seattle, CN=wolfSSL, OU=org-unit" ]
+EXPECTED="        Subject:  O=wolfSSL,C=US,ST=WA,L=Seattle,CN=wolfSSL,OU=org-unit"
+if [ "$SUBJECT" != "$EXPECTED" ]
 then
-    echo "found unexpected $SUBJECT"
+    echo "found unexpected result"
+    echo "Got      : $SUBJECT"
+    echo "Expected : $EXPECTED"
     exit 99
 fi
 rm -f tmp.cert
@@ -137,9 +140,12 @@ rm -f tmp.csr
 
 run_success "req -new -key ./certs/server-key.pem -config ./test.conf -x509 -out tmp.cert"
 SUBJECT=`./wolfssl x509 -in tmp.cert -text | grep Subject:`
-if [ "$SUBJECT" != "        Subject: C=US, ST=Montana, L=Bozeman, O=wolfSSL, CN=testing" ]
+EXPECTED="        Subject:  C=US,ST=Montana,L=Bozeman,O=wolfSSL,CN=testing"
+if [ "$SUBJECT" != "$EXPECTED" ]
 then
-    echo "found unexpected $SUBJECT"
+    echo "found unexpected result"
+    echo "Got      : $SUBJECT"
+    echo "Expected : $EXPECTED"
     exit 99
 fi
 rm -f tmp.cert


### PR DESCRIPTION
this PR also fixes default basic constraint behavior, restricting it to only when generating self signed certificates without a basic constraint set