### PR TITLE
add copy of dh to der and params functions for older FIPS builds

### DIFF
--- a/src/dh/clu_dh.c
+++ b/src/dh/clu_dh.c
@@ -23,8 +23,317 @@
 #include <wolfclu/clu_log.h>
 #include <wolfclu/clu_optargs.h>
 
-/* WOLFSSL_DH_EXTRA is needed for DER output of params and key */
-#if !defined(NO_DH) && defined(WOLFSSL_DH_EXTRA)
+#if !defined(NO_DH) && !defined(WOLFSSL_DH_EXTRA)
+/* Older FIPS builds do not have DH functions gated by WOLFSSL_DH_EXTRA.
+ * Add copy of basic implementation here, taken from wolfSSL 5.5.4
+ * (asn.c, dh.c) */
+
+#ifndef WOLFSSL_PUBLIC_MP
+    #error WOLFSSL_PUBLIC_MP needs defined if not using WOLFSSL_DH_EXTRA
+#endif
+
+
+static const byte keyDhOid[] = {42, 134, 72, 134, 247, 13, 1, 3, 1};
+
+static word32 BytePrecisionCopy(word32 value)
+{
+    word32 i;
+    for (i = (word32)sizeof(value) - 1; i; --i)
+        if (value >> ((i - 1) * WOLFSSL_BIT_SIZE))
+            break;
+
+    return i;
+}
+
+static word32 SetLengthCopy(word32 length, byte* output)
+{
+    /* Start encoding at start of buffer. */
+    word32 i = 0;
+
+    if (length < ASN_LONG_LENGTH) {
+        /* Only one byte needed to encode. */
+        if (output) {
+            /* Write out length value. */
+            output[i] = (byte)length;
+        }
+        /* Skip over length. */
+        i++;
+    }
+    else {
+        /* Calculate the number of bytes required to encode value. */
+        byte j = (byte)BytePrecisionCopy(length);
+
+        if (output) {
+            /* Encode count byte. */
+            output[i] = j | ASN_LONG_LENGTH;
+        }
+        /* Skip over count byte. */
+        i++;
+
+        /* Encode value as a big-endian byte array. */
+        for (; j > 0; --j) {
+            if (output) {
+                /* Encode next most-significant byte. */
+                output[i] = (byte)(length >> ((j - 1) * WOLFSSL_BIT_SIZE));
+            }
+            /* Skip over byte. */
+            i++;
+        }
+    }
+
+    /* Return number of bytes in encoded length. */
+    return i;
+}
+
+
+static int SetMyVersionCopy(word32 version, byte* output, int header)
+{
+    int i = 0;
+
+    if (output == NULL)
+        return BAD_FUNC_ARG;
+
+    if (header) {
+        output[i++] = ASN_CONTEXT_SPECIFIC | ASN_CONSTRUCTED;
+        output[i++] = 3;
+    }
+    output[i++] = ASN_INTEGER;
+    output[i++] = 0x01;
+    output[i++] = (byte)version;
+
+    return i;
+}
+
+
+static int SetObjectIdCopy(int len, byte* output)
+{
+    int idx = 0;
+
+    if (output) {
+        /* Write out tag. */
+        output[idx] = ASN_OBJECT_ID;
+    }
+    /* Skip tag. */
+    idx += ASN_TAG_SZ;
+    /* Encode length - passing NULL for output will not encode. */
+    idx += SetLengthCopy(len, output ? output + idx : NULL);
+
+    /* Return index after header. */
+    return idx;
+}
+
+
+static word32 SetSequenceCopy(word32 len, byte* output)
+{
+    if (output) {
+        output[0] = ASN_SEQUENCE | ASN_CONSTRUCTED;
+    }
+
+    return SetLengthCopy(len, output ? output + ASN_TAG_SZ : NULL) + ASN_TAG_SZ;
+}
+
+
+static word32 SetOctetStringCopy(word32 len, byte* output)
+{
+    if (output) {
+        output[0] = ASN_OCTET_STRING;
+    }
+
+    return SetLengthCopy(len, output ? output + ASN_TAG_SZ : NULL) + ASN_TAG_SZ;
+}
+
+
+static int SetASNIntCopy(int len, byte firstByte, byte* output)
+{
+    word32 idx = 0;
+
+    if (output) {
+        /* Write out tag. */
+        output[idx] = ASN_INTEGER;
+    }
+    /* Step over tag. */
+    idx += ASN_TAG_SZ;
+    /* Check if first byte has top bit set in which case a 0 is needed to
+     * maintain positive value. */
+    if (firstByte & 0x80) {
+        /* Add pre-prepended byte to length of data in INTEGER. */
+        len++;
+    }
+    /* Encode length - passing NULL for output will not encode. */
+    idx += SetLengthCopy(len, output ? output + idx : NULL);
+    /* Put out pre-pended 0 as well. */
+    if (firstByte & 0x80) {
+        if (output) {
+            /* Write out 0 byte. */
+            output[idx] = 0x00;
+        }
+        /* Update index. */
+        idx++;
+    }
+
+    /* Return index after header. */
+    return idx;
+}
+
+
+static int SetASNIntMPCopy(mp_int* n, int maxSz, byte* output)
+{
+    int idx = 0;
+    int leadingBit;
+    int length;
+    int err;
+
+    leadingBit = mp_leading_bit(n);
+    length = mp_unsigned_bin_size(n);
+    if (maxSz >= 0 && (1 + length + (leadingBit ? 1 : 0)) > maxSz)
+        return BUFFER_E;
+    idx = SetASNIntCopy(length, leadingBit ? 0x80 : 0x00, output);
+    if (maxSz >= 0 && (idx + length) > maxSz)
+        return BUFFER_E;
+
+    if (output) {
+        err = mp_to_unsigned_bin(n, output + idx);
+        if (err != MP_OKAY)
+            return MP_TO_E;
+    }
+    idx += length;
+
+    return idx;
+}
+
+
+int wc_DhParamsToDer(DhKey* key, byte* output, word32* outSz);
+int wc_DhParamsToDer(DhKey* key, byte* output, word32* outSz)
+{
+    word32 idx, total;
+
+    if (key == NULL || outSz == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* determine size */
+    /* integer - g */
+    idx = SetASNIntMPCopy(&key->g, -1, NULL);
+    /* integer - p */
+    idx += SetASNIntMPCopy(&key->p, -1, NULL);
+    total = idx;
+     /* sequence */
+    idx += SetSequenceCopy(idx, NULL);
+
+    if (output == NULL) {
+        *outSz = idx;
+        return LENGTH_ONLY_E;
+    }
+    /* make sure output fits in buffer */
+    if (idx > *outSz) {
+        return BUFFER_E;
+    }
+
+    /* write DH parameters */
+    /* sequence - for P and G only */
+    idx = SetSequenceCopy(total, output);
+    /* integer - p */
+    idx += SetASNIntMPCopy(&key->p, -1, output + idx);
+    /* integer - g */
+    idx += SetASNIntMPCopy(&key->g, -1, output + idx);
+    *outSz = idx;
+
+    return idx;
+}
+
+
+int wc_DhPrivKeyToDer(DhKey* key, byte* priv, word32 privSz, byte* output,
+        word32* outSz);
+int wc_DhPrivKeyToDer(DhKey* key, byte* prv, word32 prvSz, byte* output,
+        word32* outSz)
+{
+    int ret, privSz = 0, keySz;
+    word32 idx, len, total;
+    mp_int mpPriv;
+
+    if (key == NULL || outSz == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    mp_init(&mpPriv);
+    if (mp_read_unsigned_bin(&mpPriv, prv, prvSz) != 0) {
+        mp_free(&mpPriv);
+        return BAD_FUNC_ARG;
+    }
+
+    /* determine size */
+    /* octect string: priv */
+    privSz = SetASNIntMPCopy(&mpPriv, -1, NULL);
+    idx = 1 + SetLengthCopy(privSz, NULL) + privSz; /* +1 for ASN_OCTET_STRING */
+    keySz = idx;
+
+    /* DH Parameters sequence with P and G */
+    total = 0;
+    ret = wc_DhParamsToDer(key, NULL, &total);
+    if (ret != LENGTH_ONLY_E) {
+        mp_free(&mpPriv);
+        return ret;
+    }
+    idx += total;
+
+    /* object dhKeyAgreement 1.2.840.113549.1.3.1 */
+    idx += SetObjectIdCopy(sizeof(keyDhOid), NULL);
+    idx += sizeof(keyDhOid);
+    len = idx - keySz;
+    /* sequence - all but pub/priv */
+    idx += SetSequenceCopy(len, NULL);
+    /* version: 0 (ASN_INTEGER, 0x01, 0x00) */
+    idx += 3;
+    /* sequence */
+    total = idx + SetSequenceCopy(idx, NULL);
+
+    /* if no output, then just getting size */
+    if (output == NULL) {
+        *outSz = total;
+        mp_free(&mpPriv);
+        return LENGTH_ONLY_E;
+    }
+
+    /* make sure output fits in buffer */
+    if (total > *outSz) {
+        mp_free(&mpPriv);
+        return BUFFER_E;
+    }
+    total = idx;
+
+    /* sequence */
+    idx = SetSequenceCopy(total, output);
+    /* version: 0 */
+    idx += SetMyVersionCopy(0, output + idx, 0);
+    /* sequence - all but pub/priv */
+    idx += SetSequenceCopy(len, output + idx);
+    /* object dhKeyAgreement 1.2.840.113549.1.3.1 */
+    idx += SetObjectIdCopy(sizeof(keyDhOid), output + idx);
+    XMEMCPY(output + idx, keyDhOid, sizeof(keyDhOid));
+    idx += sizeof(keyDhOid);
+
+    /* DH Parameters sequence with P and G */
+    total = *outSz - idx;
+    ret = wc_DhParamsToDer(key, output + idx, &total);
+    if (ret < 0) {
+        mp_free(&mpPriv);
+        return ret;
+    }
+    idx += total;
+
+    /* octect string: priv */
+    idx += SetOctetStringCopy(privSz, output + idx);
+    idx += SetASNIntMPCopy(&mpPriv, -1, output + idx);
+    *outSz = idx;
+
+    mp_free(&mpPriv);
+    return idx;
+}
+
+#endif /* !WOLFSSL_DH_EXTRA */
+
+
+#if !defined(NO_DH)
 
 #ifndef WOLFSSL_MAX_DH_BITS
     #define WOLFSSL_MAX_DH_BITS       4096
@@ -61,7 +370,7 @@ static void wolfCLU_DhHelp(void)
 
 int wolfCLU_DhParamSetup(int argc, char** argv)
 {
-#if !defined(NO_DH) && defined(WOLFSSL_DH_EXTRA)
+#if !defined(NO_DH)
     WC_RNG rng;
     DhKey dh;
     int modSz = -1;
@@ -234,7 +543,17 @@ int wolfCLU_DhParamSetup(int argc, char** argv)
     /* generate the dh parameters */
     if (ret == WOLFCLU_SUCCESS && bioIn == NULL) {
     #if defined(HAVE_FFDHE_4096)
-        #if LIBWOLFSSL_VERSION_HEX > 0x05001000
+        #if defined(HAVE_FIPS) && FIPS_VERSION_LE(2,0)
+        if (modSz == 4096) {
+            const DhParams* params = wc_Dh_ffdhe4096_Get();
+            if (wc_DhSetKey(&dh, (byte*)params->p, params->p_len,
+                        (byte*)params->g, params->g_len) != 0) {
+                wolfCLU_LogError("Error setting named 4096 parameters");
+                ret = WOLFCLU_FATAL_ERROR;
+            }
+        }
+        else
+        #elif (LIBWOLFSSL_VERSION_HEX > 0x05001000)
         if (modSz == 4096) {
             if (wc_DhSetNamedKey(&dh, WC_FFDHE_4096) != 0) {
                 wolfCLU_LogError("Error setting named 4096 parameters");
@@ -256,6 +575,12 @@ int wolfCLU_DhParamSetup(int argc, char** argv)
     #endif /* have 4096 named parameters */
         if (wc_DhGenerateParams(&rng, modSz, &dh) != 0) {
             wolfCLU_LogError("Error generating parameters");
+        #if !defined(HAVE_FFDHE_4096)
+            if (modSz == 4096) {
+                wolfCLU_LogError("HAVE_FFDHE_4096 macro possibly needs defined "
+                        "when building wolfSSL for 4096 params");
+            }
+        #endif
             ret = WOLFCLU_FATAL_ERROR;
         }
     }
@@ -348,8 +673,7 @@ int wolfCLU_DhParamSetup(int argc, char** argv)
         }
 
         if (ret == WOLFCLU_SUCCESS) {
-            if (wc_DhSetCheckKey(&dh, p, p_len, g, g_len, q, q_len, 0, &rng)
-                    != 0) {
+            if (wc_DhSetKey_ex(&dh, p, p_len, g, g_len, q, q_len) != 0) {
                 wolfCLU_LogError("Failed to set/check DH params");
                 ret = WOLFCLU_FATAL_ERROR;
             }
@@ -403,7 +727,11 @@ int wolfCLU_DhParamSetup(int argc, char** argv)
         }
 
         if (ret == WOLFCLU_SUCCESS) {
+        #ifndef WOLFSSL_DH_EXTRA
+            ret = wc_DhPrivKeyToDer(&dh, priv, privSz, outBuf, &outBufSz);
+        #else
             ret = wc_DhPrivKeyToDer(&dh, outBuf, &outBufSz);
+        #endif
             if (ret <= 0) {
                 wolfCLU_LogError("Error converting DH key to buffer");
                 ret = WOLFCLU_FATAL_ERROR;


### PR DESCRIPTION
ZD15621

To reproduce failure do:

First build FIPS version of wolfSSL

```
cd wolfssl
./fips-check linuxv2 keep
cd XXX-fips-test
./configure --enable-fips=v2 --enable-wolfclu CPPFLAGS="-DHAVE_FFDHE_4096 -DWOLFSSL_PUBLIC_MP"
make
./fips-hash.sh
make
sudo make install
```

Then build wolfCLU

```
cd wolfclu
./configure
make
./wolfssl dhparam 4096 -out out.pem -check 4096
```

Before this change there would be an error of DHparams not supported due to WOLFSSH_DH_EXTRA not being defined with the version of FIPS. (check wolfssl/wolfcrypt/settings.h to see WOLFSSH_DH_EXTRA getting undefined).