### PR TITLE
Fix configure error that can't locate libwolfssl when using custom install location

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,9 @@ AC_ARG_WITH(wolfssl,
     if test "x$withval" != "xno" ; then
       if test -d "${withval}/lib" && test -d "${withval}/include"; then
         wcpath=${withval}
+        LDFLAGS="$LDFLAGS -L${wcpath}/lib"
         AM_LDFLAGS="$AM_LDFLAGS -L${wcpath}/lib"
+        CPPFLAGS="$CPPFLAGS -I${wcpath}/include"
         AM_CPPFLAGS="$AM_CPPFLAGS -I${wcpath}/include"
       else
         AC_MSG_ERROR([wolfSSL path error (${withval}): missing lib and include])


### PR DESCRIPTION
https://github.com/wolfSSL/wolfCLU/commit/8130d3a1a6e1edb58abf737923ca59cdeb032b6c broke all testing with master.

ACTION: Gave wolfCLU it's own CLU-PRB-manager and a test that ensures changes with wolfCLU do not negatively impact PRB testing against master as well!