### PR TITLE
removed erroneous file generation on ecc keygen

### DIFF
--- a/src/genkey/clu_genkey.c
+++ b/src/genkey/clu_genkey.c
@@ -93,7 +93,7 @@ int wolfCLU_genKey_ED25519(WC_RNG* rng, char* fOutNm, int directive, int format)
     XMEMCPY(finalOutFNm, fOutNm, fOutNmSz);
 
     switch(directive) {
-        case PRIV_AND_PUB:
+        case PRIV_AND_PUB_FILES:
             flagOutputPub = 1;
             /* Fall through to PRIV_ONLY_FILE */
             FALL_THROUGH;
@@ -484,7 +484,7 @@ int wolfCLU_GenAndOutput_ECC(WC_RNG* rng, char* fName, int directive,
 
     if (ret == WOLFCLU_SUCCESS) {
         switch(directive) {
-            case PRIV_AND_PUB:
+            case PRIV_AND_PUB_FILES:
                 /* Fall through to PRIV_ONLY_FILE */
                 FALL_THROUGH;
             case PRIV_ONLY_FILE: /* adding .priv to file name */
@@ -517,7 +517,7 @@ int wolfCLU_GenAndOutput_ECC(WC_RNG* rng, char* fName, int directive,
                 if (ret < 0) {
                     break;
                 }
-                if (directive != PRIV_AND_PUB) {
+                if (directive != PRIV_AND_PUB_FILES) {
                     break;
                 }
                 FALL_THROUGH;
@@ -677,7 +677,7 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
 
     if (ret == WOLFCLU_SUCCESS) {
         switch (directive) {
-            case PRIV_AND_PUB:
+            case PRIV_AND_PUB_FILES:
                 /* Fall through to PRIV_ONLY_FILE */
                 FALL_THROUGH;
             case PRIV_ONLY_FILE:
@@ -722,7 +722,7 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
                     XFREE(pemBuf, HEAP_HINT, DYNAMIC_TYPE_PRIVATE_KEY);
                 }
 
-                if (directive != PRIV_AND_PUB) {
+                if (directive != PRIV_AND_PUB_FILES) {
                     break;
                 }
                 FALL_THROUGH;

--- a/src/genkey/clu_genkey.c
+++ b/src/genkey/clu_genkey.c
@@ -95,9 +95,9 @@ int wolfCLU_genKey_ED25519(WC_RNG* rng, char* fOutNm, int directive, int format)
     switch(directive) {
         case PRIV_AND_PUB:
             flagOutputPub = 1;
-            /* Fall through to PRIV_ONLY */
+            /* Fall through to PRIV_ONLY_FILE */
             FALL_THROUGH;
-        case PRIV_ONLY:
+        case PRIV_ONLY_FILE:
             /* add on the final part of the file name ".priv" */
             XMEMCPY(finalOutFNm+fOutNmSz, privAppend, fOutNmAppendSz);
             WOLFCLU_LOG(WOLFCLU_L0, "finalOutFNm = %s", finalOutFNm);
@@ -118,9 +118,9 @@ int wolfCLU_genKey_ED25519(WC_RNG* rng, char* fOutNm, int directive, int format)
 
             if (flagOutputPub == 0) {
                 break;
-            } /* else fall through to PUB_ONLY if flagOutputPub == 1*/
+            } /* else fall through to PUB_ONLY_FILE if flagOutputPub == 1*/
             FALL_THROUGH;
-        case PUB_ONLY:
+        case PUB_ONLY_FILE:
             /* add on the final part of the file name ".pub" */
             XMEMCPY(finalOutFNm+fOutNmSz, pubAppend, fOutNmAppendSz);
             WOLFCLU_LOG(WOLFCLU_L0, "finalOutFNm = %s", finalOutFNm);
@@ -451,7 +451,6 @@ int wolfCLU_GenAndOutput_ECC(WC_RNG* rng, char* fName, int directive,
     char  fExtPub[6]  = ".pub\0\0";
     char* fOutNameBuf = NULL;
 
-    WOLFSSL_BIO *bioOut = NULL;
     WOLFSSL_BIO *bioPub = NULL;
     WOLFSSL_BIO *bioPri = NULL;
     WOLFSSL_EC_KEY   *key;
@@ -485,19 +484,9 @@ int wolfCLU_GenAndOutput_ECC(WC_RNG* rng, char* fName, int directive,
 
     if (ret == WOLFCLU_SUCCESS) {
         switch(directive) {
-            case PUB_ONLY:
-                if (fmt == PEM_FORM) {
-                    if (wolfSSL_PEM_write_bio_EC_PUBKEY(bioOut, key)
-                            != WOLFSSL_SUCCESS) {
-                        ret = WOLFCLU_FATAL_ERROR;
-                    }
-                }
-                else {
-                    ret = wolfCLU_ECC_write_pub_der(bioOut, key);
-                }
-                break;
             case PRIV_AND_PUB:
-                /* Fall through to PRIV_ONLY */
+                /* Fall through to PRIV_ONLY_FILE */
+                FALL_THROUGH;
             case PRIV_ONLY_FILE: /* adding .priv to file name */
                 if (ret == WOLFCLU_SUCCESS) {
                     XMEMCPY(fOutNameBuf, fName, fNameSz);
@@ -566,7 +555,6 @@ int wolfCLU_GenAndOutput_ECC(WC_RNG* rng, char* fName, int directive,
     }
 
     wolfSSL_EC_KEY_free(key);
-    wolfSSL_BIO_free(bioOut);
     wolfSSL_BIO_free(bioPri);
     wolfSSL_BIO_free(bioPub);
 
@@ -690,7 +678,7 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
     if (ret == WOLFCLU_SUCCESS) {
         switch (directive) {
             case PRIV_AND_PUB:
-                /* Fall through to PRIV_ONLY */
+                /* Fall through to PRIV_ONLY_FILE */
                 FALL_THROUGH;
             case PRIV_ONLY_FILE:
                 /* add on the final part of the file name ".priv" */

--- a/src/genkey/clu_genkey.c
+++ b/src/genkey/clu_genkey.c
@@ -474,14 +474,6 @@ int wolfCLU_GenAndOutput_ECC(WC_RNG* rng, char* fName, int directive,
         ret = WOLFCLU_FATAL_ERROR;
     }
 
-    if (ret == WOLFCLU_SUCCESS) {
-        bioOut = wolfSSL_BIO_new_file(fName, "wb");
-        if (bioOut == NULL) {
-            wolfCLU_LogError("unable to open output file %s", fName);
-            ret = MEMORY_E;
-        }
-    }
-
     /* create buffer for alternate file name use */
     if (ret == WOLFCLU_SUCCESS) {
         fOutNameBuf = (char*)XMALLOC(fNameSz + fExtSz + 1, NULL,

--- a/src/genkey/clu_genkey_setup.c
+++ b/src/genkey/clu_genkey_setup.c
@@ -101,10 +101,10 @@ int wolfCLU_genKeySetup(int argc, char** argv)
         if (ret > 0) {
             if (argv[ret+1] != NULL) {
                 if (XSTRNCMP(argv[ret+1], "pub", 3) == 0)
-                    ret = wolfCLU_genKey_ED25519(&rng, keyOutFName, PUB_ONLY,
+                    ret = wolfCLU_genKey_ED25519(&rng, keyOutFName, PUB_ONLY_FILE,
                                                                      formatArg);
                 else if (XSTRNCMP(argv[ret+1], "priv", 4) == 0)
-                    ret = wolfCLU_genKey_ED25519(&rng, keyOutFName, PRIV_ONLY,
+                    ret = wolfCLU_genKey_ED25519(&rng, keyOutFName, PRIV_ONLY_FILE,
                                                                      formatArg);
                 else if (XSTRNCMP(argv[ret+1], "keypair", 7) == 0)
                     ret = wolfCLU_genKey_ED25519(&rng, keyOutFName,

--- a/src/genkey/clu_genkey_setup.c
+++ b/src/genkey/clu_genkey_setup.c
@@ -108,13 +108,13 @@ int wolfCLU_genKeySetup(int argc, char** argv)
                                                                      formatArg);
                 else if (XSTRNCMP(argv[ret+1], "keypair", 7) == 0)
                     ret = wolfCLU_genKey_ED25519(&rng, keyOutFName,
-                                                       PRIV_AND_PUB, formatArg);
+                                                       PRIV_AND_PUB_FILES, formatArg);
             }
         }
         else {
             WOLFCLU_LOG(WOLFCLU_L0, "No -output <PUB/PRIV/KEYPAIR>");
             WOLFCLU_LOG(WOLFCLU_L0, "DEFAULT: output public and private key pair");
-            ret = wolfCLU_genKey_ED25519(&rng, keyOutFName, PRIV_AND_PUB,
+            ret = wolfCLU_genKey_ED25519(&rng, keyOutFName, PRIV_AND_PUB_FILES,
                                                                      formatArg);
         }
     #else
@@ -129,7 +129,7 @@ int wolfCLU_genKeySetup(int argc, char** argv)
     else if (XSTRNCMP(keyType, "ecc", 3) == 0) {
     #if defined(HAVE_ECC) && defined(WOLFSSL_KEY_GEN)
         /* ECC flags */
-        int directiveArg = PRIV_AND_PUB;
+        int directiveArg = PRIV_AND_PUB_FILES;
 
         WOLFCLU_LOG(WOLFCLU_L0, "generate ECC key");
 
@@ -142,13 +142,13 @@ int wolfCLU_genKeySetup(int argc, char** argv)
                 else if (XSTRNCMP(argv[ret+1], "priv", 4) == 0)
                     directiveArg = PRIV_ONLY_FILE;
                 else if (XSTRNCMP(argv[ret+1], "keypair", 7) == 0)
-                    directiveArg = PRIV_AND_PUB;
+                    directiveArg = PRIV_AND_PUB_FILES;
             }
         }
         else {
             WOLFCLU_LOG(WOLFCLU_L0, "No -output <PUB/PRIV/KEYPAIR>");
             WOLFCLU_LOG(WOLFCLU_L0, "DEFAULT: output public and private key pair");
-            directiveArg = PRIV_AND_PUB;
+            directiveArg = PRIV_AND_PUB_FILES;
         }
 
         /* get the curve name */
@@ -182,7 +182,7 @@ int wolfCLU_genKeySetup(int argc, char** argv)
     else if (XSTRNCMP(keyType, "rsa", 3) == 0) {
     #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
         /* RSA flags */
-        int directiveArg = PRIV_AND_PUB;
+        int directiveArg = PRIV_AND_PUB_FILES;
         int sizeArg = 0;
         int expArg  = 0;
 
@@ -197,13 +197,13 @@ int wolfCLU_genKeySetup(int argc, char** argv)
                 else if (XSTRNCMP(argv[ret+1], "priv", 4) == 0)
                     directiveArg = PRIV_ONLY_FILE;
                 else if (XSTRNCMP(argv[ret+1], "keypair", 7) == 0)
-                    directiveArg = PRIV_AND_PUB;
+                    directiveArg = PRIV_AND_PUB_FILES;
             }
         }
         else {
             WOLFCLU_LOG(WOLFCLU_L0, "No -output <PUB/PRIV/KEYPAIR>");
             WOLFCLU_LOG(WOLFCLU_L0, "DEFAULT: output public and private key pair");
-            directiveArg = PRIV_AND_PUB;
+            directiveArg = PRIV_AND_PUB_FILES;
         }
 
         /* get the size argument */

--- a/wolfclu/genkey/clu_genkey.h
+++ b/wolfclu/genkey/clu_genkey.h
@@ -39,8 +39,6 @@
 
 enum {
     ECPARAM,
-    PRIV_ONLY,
-    PUB_ONLY,
     PRIV_ONLY_FILE,
     PUB_ONLY_FILE,
     PRIV_AND_PUB

--- a/wolfclu/genkey/clu_genkey.h
+++ b/wolfclu/genkey/clu_genkey.h
@@ -41,7 +41,7 @@ enum {
     ECPARAM,
     PRIV_ONLY_FILE,
     PUB_ONLY_FILE,
-    PRIV_AND_PUB
+    PRIV_AND_PUB_FILES
 };
 
 /* handles incoming arguments for certificate generation */


### PR DESCRIPTION
## Changes introduced
1. Fixes bug where generating an ECC key created a zero-byte file alongside the output keys.
2. Unifies the seemingly redundant `PUB_ONLY`/`PRIV_ONLY`  and `PUB_ONLY_FILE`/`PRIV_ONLY_FILE` enums

## How to reproduce bug in 1. 
Running the following command on a build based on the `main` branch:
```
./wolfssl genkey ecc -out mykey -outform pem -output KEYPAIR
```
generates `mykey.priv` and `mykey.pub` but also the empty file `mykey`. 

This PR should eliminate the extra `mykey` file



