### PR TITLE
Sign and Verify Support with PEM format key ED25519, RSA, and ECC

### DIFF
--- a/src/genkey/clu_genkey.c
+++ b/src/genkey/clu_genkey.c
@@ -193,6 +193,14 @@ int wolfCLU_genKey_ED25519(WC_RNG* rng, char* fOutNm, int directive, int format)
             if (flagOutputPub == 0) {
                 break;
             } /* else fall through to PUB_ONLY_FILE if flagOutputPub == 1 */
+
+            XFCLOSE(file);
+            file = NULL;
+            XFREE(derBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            derBuf = NULL;
+            XFREE(pemBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            pemBuf = NULL;
+
             FALL_THROUGH;
         case PUB_ONLY_FILE:
             /* add on the final part of the file name ".pub" */
@@ -268,7 +276,6 @@ int wolfCLU_genKey_ED25519(WC_RNG* rng, char* fOutNm, int directive, int format)
             if (ret != 0) {
                 ret = OUTPUT_FILE_ERROR;
             }
-            XFCLOSE(file);
             break;
         default:
             wolfCLU_LogError("Invalid directive");
@@ -277,15 +284,19 @@ int wolfCLU_genKey_ED25519(WC_RNG* rng, char* fOutNm, int directive, int format)
     }
 
     /* cleanup allocated resources */
-    if (file != NULL) {
-        XFCLOSE(file);
+    if (finalOutFNm != NULL) {
         XFREE(finalOutFNm, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        finalOutFNm = NULL;
     }
     if (derBuf != NULL) {
         XFREE(derBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (pemBuf != NULL) {
         XFREE(pemBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (file != NULL) {
+        XFCLOSE(file);
+        file = NULL;
     }
 
     /* expected ret == WOLFCLU_SUCCESS */
@@ -886,6 +897,14 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
             if (flagOutputPub == 0) {
                 break;
             } /* else fall through to PUB_ONLY_FILE if flagOutputPub == 1 */
+
+            XFCLOSE(file);
+            file = NULL;
+            XFREE(derBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            derBuf = NULL;
+            XFREE(pemBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            pemBuf = NULL;
+
             FALL_THROUGH;
         case PUB_ONLY_FILE:
             /* add on the final part of the file name ".pub" */
@@ -961,7 +980,6 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
             if (ret != WOLFCLU_SUCCESS) {
                 ret = OUTPUT_FILE_ERROR;
             }
-            XFCLOSE(file);
             break;
         default:
             wolfCLU_LogError("Invalid directive");
@@ -969,9 +987,10 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
         } /* switch */
     }
 
-    if (file != NULL) {
-        XFCLOSE(file);
+    /* cleanup allocated resources */
+    if (fOutNameBuf != NULL) {
         XFREE(fOutNameBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        fOutNameBuf = NULL;
     }
     if (derBuf != NULL) {
         XFREE(derBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -979,6 +998,11 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
     if (pemBuf != NULL) {
         XFREE(pemBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
+     if (file != NULL) {
+        XFCLOSE(file);
+        file = NULL;
+    }
+
     wc_FreeRsaKey(&key);
 
     return ret;

--- a/src/genkey/clu_genkey.c
+++ b/src/genkey/clu_genkey.c
@@ -49,7 +49,7 @@ int wolfCLU_genKey_ED25519(WC_RNG* rng, char* fOutNm, int directive, int format)
     word32 pubKeySz;                     /* size of public key */
 #endif
     ed25519_key edKeyOut;                /* the ed25519 key structure */
-    char* finalOutFNm;                   /* file name + append */
+    char* finalOutFNm = NULL;            /* file name + append */
     XFILE file = NULL;                   /* file stream */
     byte* derBuf = NULL;                 /* buffer for DER format */
     byte* pemBuf = NULL;                 /* buffer for PEM format */
@@ -748,19 +748,19 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
                        keySz, long exp)
 {
 #ifndef NO_RSA
-    RsaKey key;                       /* the RSA key structure */
-    XFILE file = NULL;                /* file stream */
-    int ret = WOLFCLU_SUCCESS;        /* return value */
-    int fNameSz;                      /* file name without append */
-    int fExtSz = 6;                   /* # of bytes to append to file name */
-    char fExtPriv[6] = ".priv\0";     /* last part of the priv file name */
-    char fExtPub[6]  = ".pub\0\0";    /* last part of the pub file name*/
-    char* fOutNameBuf = NULL;         /* file name + fExt */
-    int flagOutputPub = 0;            /* set if outputting both priv/pub */
-    byte* derBuf = NULL;              /* buffer for DER format */
-    byte* pemBuf = NULL;              /* buffer for PEM format */
-    int derBufSz = -1;                /* size of DER buffer */
-    int pemBufSz = 0;                 /* size of PEM buffer */
+    RsaKey key;                        /* the RSA key structure */
+    XFILE file = NULL;                 /* file stream */
+    int   ret = WOLFCLU_SUCCESS;       /* return value */
+    int   fNameSz;                     /* file name without append */
+    int   fExtSz       = 6;            /* # of bytes to append to file name */
+    char  fExtPriv[6]  = ".priv\0";    /* last part of the priv file name */
+    char  fExtPub[6]   = ".pub\0\0";   /* last part of the pub file name*/
+    char* fOutNameBuf  = NULL;         /* file name + fExt */
+    int   flagOutputPub = 0;           /* set if outputting both priv/pub */
+    byte* derBuf       = NULL;         /* buffer for DER format */
+    byte* pemBuf       = NULL;         /* buffer for PEM format */
+    int   derBufSz     = -1;           /* size of DER buffer */
+    int   pemBufSz     = 0;            /* size of PEM buffer */
 
     WOLFCLU_LOG(WOLFCLU_L0, "fOutNm = %s", fName);
     fNameSz = (int)XSTRLEN(fName);

--- a/src/genkey/clu_genkey_setup.c
+++ b/src/genkey/clu_genkey_setup.c
@@ -79,8 +79,12 @@ int wolfCLU_genKeySetup(int argc, char** argv)
         format = argv[ret+1];
     }
     ret = wolfCLU_checkOutform(format);
-    if (ret == PEM_FORM || ret == DER_FORM) {
-        WOLFCLU_LOG(WOLFCLU_L0, "OUTPUT A %s FILE", (ret == PEM_FORM)? "PEM": "DER");
+    if (ret == PEM_FORM || ret == DER_FORM || ret == RAW_FORM) {
+        const char* formatStr = (ret == PEM_FORM) ? "PEM" :
+                                (ret == DER_FORM) ? "DER" :
+                                "RAW";
+
+        WOLFCLU_LOG(WOLFCLU_L0, "OUTPUT A %s FILE", formatStr);
         formatArg = ret;
     }
     else {

--- a/src/sign-verify/clu_sign.c
+++ b/src/sign-verify/clu_sign.c
@@ -465,18 +465,30 @@ int wolfCLU_sign_data_ed25519 (byte* data, char* out, word32 fSz, char* privKey,
         }
     }
 
-    /* decode the private key from the DER-encoded input */
-    if (ret == 0) {
-        ret = wc_Ed25519PrivateKeyDecode(keyBuf, &index, &key, privFileSz);
-        if (ret == 0) {
-            /* Calculate the public key */
-            ret = wc_ed25519_make_public(&key, key.p, ED25519_PUB_KEY_SIZE);
-            if (ret == 0) {
-                key.pubKeySet = 1;
-            }
+    /* retrieve RAW private key and store in the ED25519 Key */
+    if (inForm == RAW_FORM && ret == 0) {
+        ret = wc_ed25519_import_private_key(keyBuf,
+                                        ED25519_KEY_SIZE,
+                                        keyBuf + ED25519_KEY_SIZE,
+                                        ED25519_KEY_SIZE, &key);
+        if (ret != 0 ) {
+            wolfCLU_LogError("Failed to import RAW private key.\nRET: %d", ret);
         }
-        else {
-            wolfCLU_LogError("Failed to import private key.\nRET: %d", ret);
+    }
+    else {
+        /* decode the private key from the DER-encoded input */
+        if (ret == 0) {
+            ret = wc_Ed25519PrivateKeyDecode(keyBuf, &index, &key, privFileSz);
+            if (ret == 0) {
+                /* Calculate the public key */
+                ret = wc_ed25519_make_public(&key, key.p, ED25519_PUB_KEY_SIZE);
+                if (ret == 0) {
+                    key.pubKeySet = 1;
+                }
+            }
+            else {
+                wolfCLU_LogError("Failed to import private key.\nRET: %d", ret);
+            }
         }
     }
 

--- a/src/sign-verify/clu_sign_verify_setup.c
+++ b/src/sign-verify/clu_sign_verify_setup.c
@@ -24,6 +24,7 @@
 #include <wolfclu/sign-verify/clu_sign.h>
 #include <wolfclu/sign-verify/clu_verify.h>
 #include <wolfclu/sign-verify/clu_sign_verify_setup.h>
+#include <wolfclu/x509/clu_cert.h>
 
 int wolfCLU_sign_verify_setup(int argc, char** argv)
 {
@@ -39,6 +40,7 @@ int wolfCLU_sign_verify_setup(int argc, char** argv)
     int     signCheck   = 0;
     int     verifyCheck = 0;
     int     pubInCheck  = 0;
+    int     inForm  = DER_FORM; /* the key input format */
 
     /* checkForArg doesn't look for "-" here, as it would have been
      * removed in clu_main.c if present */
@@ -105,6 +107,17 @@ int wolfCLU_sign_verify_setup(int argc, char** argv)
         wolfCLU_signHelp(algCheck);
         wolfCLU_verifyHelp(algCheck);
         return ret;
+    }
+
+    ret = wolfCLU_checkForArg("-inform", 7, argc, argv);
+    if (ret > 0) {
+        inForm = wolfCLU_checkInform(argv[ret+1]);
+        if (inForm == USER_INPUT_ERROR) {
+            ret = WOLFCLU_FATAL_ERROR;
+            if (priv)
+                XFREE(priv, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            return ret;
+        }
     }
 
     ret = wolfCLU_checkForArg("-pubin", 6, argc, argv);
@@ -226,10 +239,10 @@ int wolfCLU_sign_verify_setup(int argc, char** argv)
     }
 
     if (signCheck == 1) {
-        ret = wolfCLU_sign_data(in, out, priv, algCheck);
+        ret = wolfCLU_sign_data(in, out, priv, algCheck, inForm);
     }
     else if (verifyCheck == 1) {
-        ret = wolfCLU_verify_signature(sig, in, out, priv, algCheck, pubInCheck);
+        ret = wolfCLU_verify_signature(sig, in, out, priv, algCheck, pubInCheck, inForm);
     }
 
     if (priv)

--- a/src/sign-verify/clu_verify.c
+++ b/src/sign-verify/clu_verify.c
@@ -27,130 +27,6 @@
                                            * and ED25519_SIG_VER */
 #ifndef WOLFCLU_NO_FILESYSTEM
 
-static int wolfCLU_generate_public_key_rsa(char* privKey, int inForm, byte** outBuf,
-                                           int* outBufSz)
-{
-#ifndef NO_RSA
-    int ret;
-    int privFileSz;
-    word32 index = 0;
-
-    XFILE privKeyFile;
-    byte* keyBuf = NULL;
-    RsaKey key;
-    WC_RNG rng;
-
-    if (outBuf == NULL || outBufSz == NULL) {
-        wolfCLU_LogError("Unexpected null output buffer or size variable");
-        return BAD_FUNC_ARG;
-    }
-
-    XMEMSET(&rng, 0, sizeof(rng));
-    XMEMSET(&key, 0, sizeof(key));
-
-    /* initialize RSA key */
-    ret = wc_InitRsaKey(&key, NULL);
-    if (ret != 0) {
-        wolfCLU_LogError("Failed to initialize RsaKey.\nRet: %d", ret);
-        return ret;
-    }
-
-    /* initialize RNG */
-    ret = wc_InitRng(&rng);
-    if (ret != 0) {
-        wolfCLU_LogError("Failed to initialize rng.\nRET: %d", ret);
-        wc_FreeRsaKey(&key);
-        return ret;
-    }
-
-    /* read in and store private key */
-    privKeyFile = XFOPEN(privKey, "rb");
-    if (privKeyFile == NULL) {
-        wolfCLU_LogError("unable to open file %s", privKey);
-        wc_FreeRsaKey(&key);
-        wc_FreeRng(&rng);
-        return BAD_FUNC_ARG;
-    }
-
-    XFSEEK(privKeyFile, 0, SEEK_END);
-    privFileSz = (int)XFTELL(privKeyFile);
-    keyBuf = (byte*)XMALLOC(privFileSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (keyBuf == NULL) {
-        XFCLOSE(privKeyFile);
-        wc_FreeRsaKey(&key);
-        wc_FreeRng(&rng);
-        return MEMORY_E;
-    }
-    if (XFSEEK(privKeyFile, 0, SEEK_SET) != 0 ||
-        (int)XFREAD(keyBuf, 1, privFileSz, privKeyFile) != privFileSz) {
-        XFCLOSE(privKeyFile);
-        return WOLFCLU_FATAL_ERROR;
-    }
-    XFCLOSE(privKeyFile);
-
-    /* convert PEM to DER if necessary */
-    if (inForm == PEM_FORM) {
-        ret = wolfCLU_KeyPemToDer(&keyBuf, privFileSz);
-        if (ret != 0) {
-            wolfCLU_LogError("Failed to convert PEM to DER.\nRET: %d", ret);
-            XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            wc_FreeRsaKey(&key);
-            wc_FreeRng(&rng);
-            return ret;
-        }
-    }
-
-    /* retrieve private key and store in the RsaKey */
-    if (ret == 0) {
-        ret = wc_RsaPrivateKeyDecode(keyBuf, &index, &key, privFileSz);
-        if (ret != 0) {
-            wolfCLU_LogError("Failed to decode private key.\nRET: %d", ret);
-        }
-    }
-
-    /* calculate the size needed for the public key */
-    if (ret == 0) {
-        ret = wc_RsaKeyToPublicDer(&key, NULL, 0);
-        if (ret < 0) {
-            wolfCLU_LogError("Failed to export RSA public key.\nRET: %d", ret);
-        } else {
-            *outBufSz = ret;
-            ret = 0;
-        }
-    }
-
-    /* allocate buffer for the public key */
-    if (ret == 0) {
-        *outBuf = (byte*)XMALLOC(*outBufSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        if (*outBuf == NULL) {
-            wolfCLU_LogError("Failed to allocate memory for public key.\nSize: %d",
-                             *outBufSz);
-            ret = MEMORY_E;
-        } else {
-            XMEMSET(*outBuf, 0, *outBufSz);
-            ret = wc_RsaKeyToPublicDer(&key, *outBuf, (word32)*outBufSz);
-            if (ret < 0) {
-                wolfCLU_LogError("Failed to export RSA public key.\nRET: %d", ret);
-                *outBufSz = ret;
-            }
-        }
-    }
-
-    /* cleanup allocated resources */
-    if (keyBuf != NULL) {
-        XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    }
-
-    wc_FreeRsaKey(&key);
-    wc_FreeRng(&rng);
-
-    /* expected ret == WOLFCLU_SUCCESS */
-    return (ret >= 0) ? WOLFCLU_SUCCESS : ret;
-#else
-    return NOT_COMPILED_IN;
-#endif
-}
-
 static int wolfCLU_generate_public_key_ed25519(char* privKey, int inForm, byte* outBuf,
                                                word32 outLen)
 {
@@ -209,12 +85,14 @@ static int wolfCLU_generate_public_key_ed25519(char* privKey, int inForm, byte* 
     /* convert PEM to DER if necessary */
     if (inForm == PEM_FORM) {
         ret = wolfCLU_KeyPemToDer(&keyBuf, 0);
-        if (ret != 0) {
+        if (ret < 0) {
             wolfCLU_LogError("Failed to convert PEM to DER.\nRET: %d", ret);
             XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            wc_ed25519_free(&key);
-            wc_FreeRng(&rng);
             return ret;
+        }
+        else {
+            privFileSz = ret;
+            ret = 0;
         }
     }
 
@@ -385,7 +263,6 @@ int wolfCLU_verify_signature_rsa(byte* sig, char* out, int sigSz, char* keyPath,
     word32 index = 0;
     XFILE keyPathFile = NULL;
     RsaKey key;
-    WC_RNG rng;
     byte* keyBuf = NULL;
     byte* outBuf = NULL;
     int   outBufSz = 0;
@@ -400,42 +277,43 @@ int wolfCLU_verify_signature_rsa(byte* sig, char* out, int sigSz, char* keyPath,
         return ret;
     }
 
-    /* retrieve public key and store in the RSA key */
-    if (pubIn == 1) {
-        /* open, read, and store RSA key  */
-        keyPathFile = XFOPEN(keyPath, "rb");
-        if (keyPathFile == NULL) {
-            wolfCLU_LogError("unable to open file %s", keyPath);
-            wc_FreeRng(&rng);
-            return BAD_FUNC_ARG;
-        }
+    /* open, read, and store RSA key  */
+    keyPathFile = XFOPEN(keyPath, "rb");
+    if (keyPathFile == NULL) {
+        wolfCLU_LogError("unable to open file %s", keyPath);
+        return BAD_FUNC_ARG;
+    }
 
-        XFSEEK(keyPathFile, 0, SEEK_END);
-        keyFileSz = (int)XFTELL(keyPathFile);
-        keyBuf = (byte*)XMALLOC(keyFileSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        if (keyBuf == NULL) {
-            XFCLOSE(keyPathFile);
-            wc_FreeRng(&rng);
-            return MEMORY_E;
-        }
-
-        if (XFSEEK(keyPathFile, 0, SEEK_SET) != 0 ||
-            (int)XFREAD(keyBuf, 1, keyFileSz, keyPathFile) != keyFileSz) {
-            XFCLOSE(keyPathFile);
-            return WOLFCLU_FATAL_ERROR;
-        }
+    XFSEEK(keyPathFile, 0, SEEK_END);
+    keyFileSz = (int)XFTELL(keyPathFile);
+    keyBuf = (byte*)XMALLOC(keyFileSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (keyBuf == NULL) {
         XFCLOSE(keyPathFile);
+        return MEMORY_E;
+    }
 
-         /* convert public key to DER format if PEM */
-        if (inForm == PEM_FORM) {
-            ret = wc_RsaKeyToPublicDer(&key, keyBuf, keyFileSz);
-            if (ret != 0) {
-                wolfCLU_LogError("Failed to convert public key to DER.\nRET: %d", ret);
-                XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                return ret;
-            }
+    if (XFSEEK(keyPathFile, 0, SEEK_SET) != 0 ||
+        (int)XFREAD(keyBuf, 1, keyFileSz, keyPathFile) != keyFileSz) {
+        XFCLOSE(keyPathFile);
+        return WOLFCLU_FATAL_ERROR;
+    }
+    XFCLOSE(keyPathFile);
+
+    /* convert PEM to DER if necessary */
+    if (inForm == PEM_FORM) {
+        ret = wolfCLU_KeyPemToDer(&keyBuf, pubIn);
+        if (ret < 0) {
+            wolfCLU_LogError("Failed to convert PEM to DER.\nRET: %d", ret);
+            XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            return ret;
         }
+        else {
+            keyFileSz = ret;
+            ret = 0;
+        }
+    }
 
+    if (pubIn == 1) {
         /* decode public key from DER-encoded input */
         ret = wc_RsaPublicKeyDecode(keyBuf, &index, &key, keyFileSz);
         if (ret != 0) {
@@ -445,23 +323,10 @@ int wolfCLU_verify_signature_rsa(byte* sig, char* out, int sigSz, char* keyPath,
         }
     }
     else {
-        /* convert PEM to DER if necessary */
-        if (inForm == PEM_FORM) {
-            ret = wolfCLU_KeyPemToDer(&keyBuf, 0);
-            if (ret != 0) {
-                wolfCLU_LogError("Failed to convert PEM to DER.\nRET: %d", ret);
-                XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                wc_FreeRng(&rng);
-                return ret;
-            }
-        }
-
-        /* derive public key from private key */
-        ret = wolfCLU_generate_public_key_rsa(keyPath, inForm, &keyBuf, &keyFileSz);
+        /* retrieve private key and store in the RsaKey */
+        ret = wc_RsaPrivateKeyDecode(keyBuf, &index, &key, keyFileSz);
         if (ret != 0) {
-            wolfCLU_LogError("Failed to derive public key from private key.");
-            XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            return ret;
+            wolfCLU_LogError("Failed to decode private key.\nRET: %d", ret);
         }
     }
 
@@ -524,25 +389,27 @@ int wolfCLU_verify_signature_ecc(byte* sig, int sigSz, byte* hash, int hashSz,
 
 #ifdef HAVE_ECC
     int ret;
-    int keyFileSz;
+    int keyFileSz = 0;
     int stat = 0;
     word32 index = 0;
 
     XFILE   keyPathFile;
     ecc_key key;
-    WC_RNG  rng;
-    byte*   keyBuf;
+    byte* keyBuf = NULL;
+    byte* outBuf = NULL;
+    int outBufSz = 0;
 
-    XMEMSET(&rng, 0, sizeof(rng));
     XMEMSET(&key, 0, sizeof(key));
 
+    /* initialize Ecc key */
     ret = wc_ecc_init(&key);
     if (ret != 0) {
         wolfCLU_LogError("Failed to initialize ecc key.\nRet: %d", ret);
+        XFREE(&key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return ret;
     }
 
-    /* read in and store ecc key */
+    /* open, read, and store Ecc key  */
     keyPathFile = XFOPEN(keyPath, "rb");
     if (keyPathFile == NULL) {
         wolfCLU_LogError("unable to open file %s", keyPath);
@@ -552,48 +419,69 @@ int wolfCLU_verify_signature_ecc(byte* sig, int sigSz, byte* hash, int hashSz,
     XFSEEK(keyPathFile, 0, SEEK_END);
     keyFileSz = (int)XFTELL(keyPathFile);
     keyBuf = (byte*)XMALLOC(keyFileSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (keyBuf != NULL) {
-        if (XFSEEK(keyPathFile, 0, SEEK_SET) != 0 ||
-                   (int)XFREAD(keyBuf, 1, keyFileSz, keyPathFile) != keyFileSz) {
-                XFCLOSE(keyPathFile);
-                return WOLFCLU_FATAL_ERROR;
-            }
+    if (keyBuf == NULL) {
+        XFCLOSE(keyPathFile);
+        return MEMORY_E;
+    }
+
+    if (XFSEEK(keyPathFile, 0, SEEK_SET) != 0 ||
+        (int)XFREAD(keyBuf, 1, keyFileSz, keyPathFile) != keyFileSz) {
+        XFCLOSE(keyPathFile);
+        return WOLFCLU_FATAL_ERROR;
     }
     XFCLOSE(keyPathFile);
 
     /* convert PEM to DER if necessary */
     if (inForm == PEM_FORM) {
         ret = wolfCLU_KeyPemToDer(&keyBuf, pubIn);
-        if (ret != 0) {
+        if (ret < 0) {
             wolfCLU_LogError("Failed to convert PEM to DER.\nRET: %d", ret);
             XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            wc_FreeRng(&rng);
             return ret;
+        }
+        else {
+            keyFileSz = ret;
+            ret = 0;
         }
     }
 
     if (pubIn == 1) {
-        /* retrieving public key and storing in the ecc key */
+        /* retrieve public key and store in the Ecc key */
         ret = wc_EccPublicKeyDecode(keyBuf, &index, &key, keyFileSz);
         if (ret < 0 ) {
             wolfCLU_LogError("Failed to decode public key.\nRET: %d", ret);
             XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             return ret;
         }
+
     }
     else {
-        /* retrieving private key and storing in the Ecc Key */
+        /* retrieve private key and store in the Ecc Key */
         ret = wc_EccPrivateKeyDecode(keyBuf, &index, &key, keyFileSz);
+        XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         if (ret != 0 ) {
-            wolfCLU_LogError("Failed to decode private key.\nRET: %d", ret);
-            XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            wolfCLU_LogError("Failed to decode Ecc private key.\nRET: %d", ret);
+            wc_ecc_free(&key);
             return ret;
         }
     }
 
-    if (keyBuf)
-        XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    /* setting up output buffer based on key size */
+    outBufSz = wc_ecc_sig_size(&key);
+    if (outBufSz <= 0) {
+        wolfCLU_LogError("Invalid output buffer size: %d", outBufSz);
+        wc_ecc_free(&key);
+        return WOLFCLU_FATAL_ERROR;
+    }
+    outBuf = (byte*)XMALLOC(outBufSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (outBuf == NULL) {
+        wolfCLU_LogError("Failed to malloc output buffer");
+        wc_ecc_free(&key);
+        return MEMORY_E;
+    }
+    XMEMSET(outBuf, 0, outBufSz);
 
+    /* verify data with Ecc public key */
     ret = wc_ecc_verify_hash(sig, sigSz, hash, hashSz, &stat, &key);
     if (ret < 0) {
         wolfCLU_LogError("Failed to verify data with Ecc public key.\nRET: %d", ret);
@@ -606,7 +494,15 @@ int wolfCLU_verify_signature_ecc(byte* sig, int sigSz, byte* hash, int hashSz,
         wolfCLU_LogError("Invalid Signature.");
     }
 
-    return WOLFCLU_SUCCESS;
+    /* Cleanup allocated resources */
+    if (outBuf != NULL) {
+        XFREE(outBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+
+     wc_ecc_free(&key);
+
+    /* expected ret == WOLFCLU_SUCCESS */
+    return (ret >= 0) ? WOLFCLU_SUCCESS : ret;
 #else
     return NOT_COMPILED_IN;
 #endif
@@ -619,10 +515,9 @@ int wolfCLU_verify_signature_ed25519(byte* sig, int sigSz,
     int ret;
     int stat = 0;
     word32 index = 0;
-    int keyFileSz;
+    int keyFileSz = 0;
 
     XFILE keyPathFile;
-    WC_RNG  rng;
     ed25519_key key;
     byte* keyBuf = (byte*)XMALLOC(ED25519_KEY_SIZE, HEAP_HINT,
             DYNAMIC_TYPE_TMP_BUFFER);
@@ -642,42 +537,45 @@ int wolfCLU_verify_signature_ed25519(byte* sig, int sigSz,
         return ret;
     }
 
-    /* retrieve public key and store in the ED25519 key */
-    if (pubIn == 1) {
-        /* open, read, and store ED25519 key  */
-        keyPathFile = XFOPEN(keyPath, "rb");
-        if (keyPathFile == NULL) {
-            wolfCLU_LogError("unable to open file %s", keyPath);
-            wc_FreeRng(&rng);
-            return BAD_FUNC_ARG;
-        }
+    /* open, read, and store ED25519 key */
+    keyPathFile = XFOPEN(keyPath, "rb");
+    if (keyPathFile == NULL) {
+        wolfCLU_LogError("unable to open file %s", keyPath);
+        return BAD_FUNC_ARG;
+    }
 
-        XFSEEK(keyPathFile, 0, SEEK_END);
-        keyFileSz = (int)XFTELL(keyPathFile);
-        keyBuf = (byte*)XMALLOC(keyFileSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        if (keyBuf == NULL) {
-            XFCLOSE(keyPathFile);
-            wc_FreeRng(&rng);
-            return MEMORY_E;
-        }
+    XFSEEK(keyPathFile, 0, SEEK_END);
+    keyFileSz = (int)XFTELL(keyPathFile);
+    XFSEEK(keyPathFile, 0, SEEK_SET);
 
-        if (XFSEEK(keyPathFile, 0, SEEK_SET) != 0 ||
-            (int)XFREAD(keyBuf, 1, keyFileSz, keyPathFile) != keyFileSz) {
-            XFCLOSE(keyPathFile);
-            return WOLFCLU_FATAL_ERROR;
-        }
+    keyBuf = (byte*)XMALLOC(keyFileSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (keyBuf == NULL) {
         XFCLOSE(keyPathFile);
+        return MEMORY_E;
+    }
 
-        /* convert public key to DER format if PEM */
-        if (inForm == PEM_FORM) {
-            ret = wc_Ed25519PublicKeyToDer(&key, keyBuf, keyFileSz, ED25519_KEY_SIZE);
-            if (ret != 0) {
-                wolfCLU_LogError("Failed to convert public key to DER.\nRET: %d", ret);
-                XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                return ret;
-            }
+    if ((int)XFREAD(keyBuf, 1, keyFileSz, keyPathFile) != keyFileSz) {
+        XFCLOSE(keyPathFile);
+        XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        return WOLFCLU_FATAL_ERROR;
+    }
+    XFCLOSE(keyPathFile);
+
+    /* convert PEM to DER if necessary */
+    if (inForm == PEM_FORM) {
+        ret = wolfCLU_KeyPemToDer(&keyBuf, pubIn);
+        if (ret < 0) {
+            wolfCLU_LogError("Failed to convert PEM to DER.\nRET: %d", ret);
+            XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            return ret;
         }
+        else {
+            keyFileSz = ret;
+            ret = 0;
+        }
+    }
 
+    if (pubIn == 1) {
         /* decode public key from DER-encoded input */
         ret = wc_Ed25519PublicKeyDecode(keyBuf, &index, &key, keyFileSz);
         if (ret != 0) {
@@ -687,23 +585,17 @@ int wolfCLU_verify_signature_ed25519(byte* sig, int sigSz,
         }
     }
     else {
-        /* convert PEM to DER if necessary */
-        if (inForm == PEM_FORM) {
-            ret = wolfCLU_KeyPemToDer(&keyBuf, 0);
-            if (ret != 0) {
-                wolfCLU_LogError("Failed to convert PEM to DER.\nRET: %d", ret);
-                XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                wc_FreeRng(&rng);
+        /* derive public key from private key */
+        if (ret == 0) {
+            ret = wolfCLU_generate_public_key_ed25519(keyPath, inForm, keyBuf,
+                                                      ED25519_KEY_SIZE);
+            if (ret == WOLFCLU_SUCCESS) {
+               ret = 0;
+            }
+            else {
+                wolfCLU_LogError("Failed to verify data with ed25519 public key.\nRET: %d", ret);
                 return ret;
             }
-        }
-
-        /* derive public key from private key */
-        ret = wolfCLU_generate_public_key_ed25519(keyPath, inForm, keyBuf, ED25519_KEY_SIZE);
-        if (ret != 0) {
-            wolfCLU_LogError("Failed to derive public key from private key.");
-            XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            return ret;
         }
 
         /* decode public key */
@@ -714,11 +606,10 @@ int wolfCLU_verify_signature_ed25519(byte* sig, int sigSz,
             return ret;
         }
     }
-    XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 
     /* verify data with ED25519 public key */
     ret = wc_ed25519_verify_msg(sig, sigSz, hash, hashSz, &stat, &key);
-    if (ret != 0) {
+    if (ret < 0) {
         wolfCLU_LogError("Failed to verify data with ED25519 public key.\nRET: %d", ret);
         return ret;
     }
@@ -729,7 +620,12 @@ int wolfCLU_verify_signature_ed25519(byte* sig, int sigSz,
         wolfCLU_LogError("Invalid Signature.");
     }
 
-    return WOLFCLU_SUCCESS;
+    /* Cleanup allocated resources */
+    XFREE(keyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    wc_ed25519_free(&key);
+
+    /* expected ret == WOLFCLU_SUCCESS */
+    return (ret >= 0) ? WOLFCLU_SUCCESS : ret;
 #else
     return NOT_COMPILED_IN;
 #endif

--- a/src/tools/clu_funcs.c
+++ b/src/tools/clu_funcs.c
@@ -1098,7 +1098,7 @@ int wolfCLU_checkForArg(const char* searchTerm, int length, int argc,
 int wolfCLU_checkOutform(char* outform)
 {
     if (outform == NULL) {
-        WOLFCLU_LOG(WOLFCLU_L0, "Usage: -outform [PEM/DER]");
+        WOLFCLU_LOG(WOLFCLU_L0, "Usage: -outform [PEM/DER/RAW]");
         WOLFCLU_LOG(WOLFCLU_L0, "missing outform required argument");
         return USER_INPUT_ERROR;
     }
@@ -1110,8 +1110,11 @@ int wolfCLU_checkOutform(char* outform)
     else if (XSTRNCMP(outform, "der", 3) == 0) {
         return DER_FORM;
     }
+    else if (XSTRNCMP(outform, "raw", 3) == 0) {
+        return RAW_FORM;
+    }
     else {
-        WOLFCLU_LOG(WOLFCLU_L0, "Usage: -outform [PEM/DER]");
+        WOLFCLU_LOG(WOLFCLU_L0, "Usage: -outform [PEM/DER/RAW]");
         WOLFCLU_LOG(WOLFCLU_L0, "\"%s\" is not a valid output format", outform);
     }
     return USER_INPUT_ERROR;
@@ -1120,7 +1123,7 @@ int wolfCLU_checkOutform(char* outform)
 int wolfCLU_checkInform(char* inform)
 {
     if (inform == NULL) {
-        WOLFCLU_LOG(WOLFCLU_L0, "Usage: -inform [PEM/DER]");
+        WOLFCLU_LOG(WOLFCLU_L0, "Usage: -inform [PEM/DER/RAW]");
         WOLFCLU_LOG(WOLFCLU_L0, "missing inform required argument");
         return USER_INPUT_ERROR;
     }
@@ -1132,8 +1135,11 @@ int wolfCLU_checkInform(char* inform)
     else if (XSTRNCMP(inform, "der", 3) == 0) {
         return DER_FORM;
     }
+    else if (XSTRNCMP(inform, "raw", 3) == 0) {
+        return RAW_FORM;
+    }
     else {
-        WOLFCLU_LOG(WOLFCLU_L0, "Usage: -inform [PEM/DER]");
+        WOLFCLU_LOG(WOLFCLU_L0, "Usage: -inform [PEM/DER/RAW]");
         WOLFCLU_LOG(WOLFCLU_L0, "\"%s\" is not a valid input format", inform);
     }
     return USER_INPUT_ERROR;

--- a/tests/genkey_sign_ver/genkey-sign-ver-test.sh
+++ b/tests/genkey_sign_ver/genkey-sign-ver-test.sh
@@ -155,25 +155,25 @@ DERPEMRAW="pem"
 VERIFYOUTNAME="rsa-sigout"
 gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
 
-: '
+# TODO - raw support
 ALGORITHM="ed25519"
 KEYFILENAME="edkey"
 SIGOUTNAME="ed-signed.sig"
 DERPEMRAW="raw"
-gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
+# gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
 
 ALGORITHM="ecc"
 KEYFILENAME="ecckey"
 SIGOUTNAME="ecc-signed.sig"
 DERPEMRAW="raw"
-gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
+# gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
 
 ALGORITHM="rsa"
 KEYFILENAME="rsakey"
 SIGOUTNAME="rsa-signed.sig"
 DERPEMRAW="raw"
 VERIFYOUTNAME="rsa-sigout"
-gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
-'
+# gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
+
 
 exit 0

--- a/tests/genkey_sign_ver/genkey-sign-ver-test.sh
+++ b/tests/genkey_sign_ver/genkey-sign-ver-test.sh
@@ -23,8 +23,6 @@
 #/
 #
 
-set -x
-
 # Skip test if filesystem disabled
 FILESYSTEM=`cat config.log | grep "disable\-filesystem"`
 if [ "$FILESYSTEM" != "" ]
@@ -155,25 +153,10 @@ DERPEMRAW="pem"
 VERIFYOUTNAME="rsa-sigout"
 gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
 
-# TODO - raw support
-# ALGORITHM="ed25519"
-# KEYFILENAME="edkey"
-# SIGOUTNAME="ed-signed.sig"
-# DERPEMRAW="raw"
-# gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
-
-# ALGORITHM="ecc"
-# KEYFILENAME="ecckey"
-# SIGOUTNAME="ecc-signed.sig"
-# DERPEMRAW="raw"
-# gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
-
-# ALGORITHM="rsa"
-# KEYFILENAME="rsakey"
-# SIGOUTNAME="rsa-signed.sig"
-# DERPEMRAW="raw"
-# VERIFYOUTNAME="rsa-sigout"
-# gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
-
+ALGORITHM="ed25519"
+KEYFILENAME="edkey"
+SIGOUTNAME="ed-signed.sig"
+DERPEMRAW="raw"
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
 
 exit 0

--- a/tests/genkey_sign_ver/genkey-sign-ver-test.sh
+++ b/tests/genkey_sign_ver/genkey-sign-ver-test.sh
@@ -156,23 +156,23 @@ VERIFYOUTNAME="rsa-sigout"
 gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
 
 # TODO - raw support
-ALGORITHM="ed25519"
-KEYFILENAME="edkey"
-SIGOUTNAME="ed-signed.sig"
-DERPEMRAW="raw"
+# ALGORITHM="ed25519"
+# KEYFILENAME="edkey"
+# SIGOUTNAME="ed-signed.sig"
+# DERPEMRAW="raw"
 # gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
 
-ALGORITHM="ecc"
-KEYFILENAME="ecckey"
-SIGOUTNAME="ecc-signed.sig"
-DERPEMRAW="raw"
+# ALGORITHM="ecc"
+# KEYFILENAME="ecckey"
+# SIGOUTNAME="ecc-signed.sig"
+# DERPEMRAW="raw"
 # gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
 
-ALGORITHM="rsa"
-KEYFILENAME="rsakey"
-SIGOUTNAME="rsa-signed.sig"
-DERPEMRAW="raw"
-VERIFYOUTNAME="rsa-sigout"
+# ALGORITHM="rsa"
+# KEYFILENAME="rsakey"
+# SIGOUTNAME="rsa-signed.sig"
+# DERPEMRAW="raw"
+# VERIFYOUTNAME="rsa-sigout"
 # gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
 
 

--- a/tests/genkey_sign_ver/genkey-sign-ver-test.sh
+++ b/tests/genkey_sign_ver/genkey-sign-ver-test.sh
@@ -23,6 +23,8 @@
 #/
 #
 
+set -x
+
 # Skip test if filesystem disabled
 FILESYSTEM=`cat config.log | grep "disable\-filesystem"`
 if [ "$FILESYSTEM" != "" ]
@@ -66,7 +68,7 @@ rsa_compare_decrypted(){
 gen_key_sign_ver_test(){
 
     # generate a key pair for signing
-    ./wolfssl -genkey $1 -out $2 -outform der KEYPAIR
+    ./wolfssl -genkey $1 -out $2 -outform $4 KEYPAIR
     RESULT=$?
     printf '%s\n' "genkey RESULT - $RESULT"
     [ $RESULT -ne 0 ] && printf '%s\n' "Failed $1 genkey" && \
@@ -74,40 +76,40 @@ gen_key_sign_ver_test(){
     printf '%s\n' "--enable-keygen" && exit -1
 
     # test signing with priv key
-    ./wolfssl -$1 -sign -inkey $2.priv -in sign-this.txt -out $3
+    ./wolfssl -$1 -sign -inkey $2.priv -inform $4 -in sign-this.txt -out $3
     RESULT=$?
     printf '%s\n' "sign RESULT - $RESULT"
     [ $RESULT -ne 0 ] && printf '%s\n' "Failed $1 sign" && exit -1
 
     # test verifying with priv key
     if [ "${1}" = "rsa" ]; then
-        ./wolfssl -$1 -verify -inkey $2.priv -sigfile $3 -in sign-this.txt \
-                  -out $4.private_result
+        ./wolfssl -$1 -verify -inkey $2.priv -inform $4 -sigfile $3 -in sign-this.txt \
+                  -out $5.private_result
     else
-        ./wolfssl -$1 -verify -inkey $2.priv -sigfile $3 -in sign-this.txt
+        ./wolfssl -$1 -verify -inkey $2.priv -inform $4 -sigfile $3 -in sign-this.txt
     fi
     RESULT=$?
     printf '%s\n' "private verify RESULT - $RESULT"
-    [ $RESULT -ne 0 ] && printf '%s\n' "Failed $1 sign" && exit -1
+    [ $RESULT -ne 0 ] && printf '%s\n' "Failed $1 private verify" && exit -1
 
     # test verifying with pub key
     if [ "${1}" = "rsa" ]; then
-        ./wolfssl -$1 -verify -inkey $2.pub -sigfile $3 -in sign-this.txt \
-                  -out $4.public_result -pubin
+        ./wolfssl -$1 -verify -inkey $2.pub -inform $4 -sigfile $3 -in sign-this.txt \
+                  -out $5.public_result -pubin
     else
-        ./wolfssl -$1 -verify -inkey $2.pub -sigfile $3 -in sign-this.txt -pubin
+        ./wolfssl -$1 -verify -inkey $2.pub -inform $4 -sigfile $3 -in sign-this.txt -pubin
     fi
     RESULT=$?
     printf '%s\n' "public verify RESULT - $RESULT"
-    [ $RESULT -ne 0 ] && printf '%s\n' "Failed $1 sign" && exit -1
+    [ $RESULT -ne 0 ] && printf '%s\n' "Failed $1 public verify " && exit -1
 
     if [ $1 = "rsa" ]; then
         ORIGINAL=`cat -A sign-this.txt`
 
-        DECRYPTED=`cat -A $4.private_result`
+        DECRYPTED=`cat -A $5.private_result`
         rsa_compare_decrypted "${DECRYPTED}" "${ORIGINAL}"
 
-        DECRYPTED=`cat -A $4.public_result`
+        DECRYPTED=`cat -A $5.public_result`
         rsa_compare_decrypted "${DECRYPTED}" "${ORIGINAL}"
     fi
 
@@ -118,17 +120,60 @@ create_sign_data_file
 ALGORITHM="ed25519"
 KEYFILENAME="edkey"
 SIGOUTNAME="ed-signed.sig"
-gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME}
+DERPEMRAW="der"
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
 
 ALGORITHM="ecc"
 KEYFILENAME="ecckey"
 SIGOUTNAME="ecc-signed.sig"
-gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME}
+DERPEMRAW="der"
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
 
 ALGORITHM="rsa"
 KEYFILENAME="rsakey"
 SIGOUTNAME="rsa-signed.sig"
+DERPEMRAW="der"
 VERIFYOUTNAME="rsa-sigout"
-gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${VERIFYOUTNAME}
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
+
+ALGORITHM="ed25519"
+KEYFILENAME="edkey"
+SIGOUTNAME="ed-signed.sig"
+DERPEMRAW="pem"
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
+
+ALGORITHM="ecc"
+KEYFILENAME="ecckey"
+SIGOUTNAME="ecc-signed.sig"
+DERPEMRAW="pem"
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
+
+ALGORITHM="rsa"
+KEYFILENAME="rsakey"
+SIGOUTNAME="rsa-signed.sig"
+DERPEMRAW="pem"
+VERIFYOUTNAME="rsa-sigout"
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
+
+: '
+ALGORITHM="ed25519"
+KEYFILENAME="edkey"
+SIGOUTNAME="ed-signed.sig"
+DERPEMRAW="raw"
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
+
+ALGORITHM="ecc"
+KEYFILENAME="ecckey"
+SIGOUTNAME="ecc-signed.sig"
+DERPEMRAW="raw"
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW}
+
+ALGORITHM="rsa"
+KEYFILENAME="rsakey"
+SIGOUTNAME="rsa-signed.sig"
+DERPEMRAW="raw"
+VERIFYOUTNAME="rsa-sigout"
+gen_key_sign_ver_test ${ALGORITHM} ${KEYFILENAME} ${SIGOUTNAME} ${DERPEMRAW} ${VERIFYOUTNAME}
+'
 
 exit 0

--- a/wolfclu/sign-verify/clu_sign.h
+++ b/wolfclu/sign-verify/clu_sign.h
@@ -39,11 +39,12 @@ enum {
     ED25519_SIG_VER,
 };
 
-int wolfCLU_sign_data(char*, char*, char*, int);
+int wolfCLU_sign_data(char*, char*, char*, int, int);
 
 
-int wolfCLU_sign_data_rsa(byte*, char*, word32, char*);
-int wolfCLU_sign_data_ecc(byte*, char*, word32, char*);
-int wolfCLU_sign_data_ed25519(byte*, char*, word32, char*);
+int wolfCLU_sign_data_rsa(byte*, char*, word32, char*, int);
+int wolfCLU_sign_data_ecc(byte*, char*, word32, char*, int);
+int wolfCLU_sign_data_ed25519(byte*, char*, word32, char*, int);
 
+int wolfCLU_KeyPemToDer(unsigned char** pkeyBuf, int pubIn);
 

--- a/wolfclu/sign-verify/clu_sign.h
+++ b/wolfclu/sign-verify/clu_sign.h
@@ -46,5 +46,5 @@ int wolfCLU_sign_data_rsa(byte*, char*, word32, char*, int);
 int wolfCLU_sign_data_ecc(byte*, char*, word32, char*, int);
 int wolfCLU_sign_data_ed25519(byte*, char*, word32, char*, int);
 
-int wolfCLU_KeyPemToDer(unsigned char** pkeyBuf, int pubIn);
+int wolfCLU_KeyPemToDer(unsigned char** pkeyBuf, int pkeySz, int pubIn);
 

--- a/wolfclu/sign-verify/clu_verify.h
+++ b/wolfclu/sign-verify/clu_verify.h
@@ -36,8 +36,8 @@
 int wolfCLU_x509Verify(int argc, char** argv);
 int wolfCLU_CRLVerify(int argc, char** argv);
 
-int wolfCLU_verify_signature(char* , char*, char*, char*, int, int);
+int wolfCLU_verify_signature(char* , char*, char*, char*, int, int, int);
 
-int wolfCLU_verify_signature_rsa(byte* , char*, int, char*, int);
-int wolfCLU_verify_signature_ecc(byte*, int, byte*, int, char*, int);
-int wolfCLU_verify_signature_ed25519(byte*, int, byte*, int, char*, int);
+int wolfCLU_verify_signature_rsa(byte* , char*, int, char*, int, int);
+int wolfCLU_verify_signature_ecc(byte*, int, byte*, int, char*, int, int);
+int wolfCLU_verify_signature_ed25519(byte*, int, byte*, int, char*, int, int);

--- a/wolfclu/x509/clu_cert.h
+++ b/wolfclu/x509/clu_cert.h
@@ -24,6 +24,7 @@
 
 #define PEM_FORM 1
 #define DER_FORM 2
+#define RAW_FORM 3
 
 /* handles incoming arguments for certificate generation */
 int wolfCLU_certSetup(int argc, char** argv);


### PR DESCRIPTION
# Description 

Sign and Verify Support with PEM and DER keys ED25519, RSA, and ECC. 
RAW support for ED25519. 

# Testing 

wolfSSL config
```
./configure --enable-wolfclu --enable-keygen --enable-all --enable-debug
```

wolfCLU 
``` 
./configure --enable-all --enable-debug 
make
make check 
./tests/genkey_sign_ver/genkey-sign-ver-test.sh
``` 
