### PR TITLE
Fix for setting wrong version in CSRs.

### DIFF
--- a/tests/x509/x509-req-test.sh
+++ b/tests/x509/x509-req-test.sh
@@ -292,7 +292,31 @@ if [ $? -eq 0 ]; then
         echo "no surname attribute found"
         exit 99
     fi
+
 fi
+
+# test csr version
+run_success "req -new -key ./certs/server-key.pem -config ./test.conf -out tmp.csr"
+RESULT=`./wolfssl req -text -noout -in tmp.csr`
+if [ $? -eq 0 ]; then
+    # also check that the version is fine.
+    echo $RESULT | grep "Version" | grep "1" | grep "0x0"
+    if [ $? -ne 0 ]; then
+        echo "Printing wrong version number"
+        exit 99
+    fi
+fi
+
+# now make sure that openssl also sees what we see.
+RESULT=`openssl req -text -noout -in tmp.csr`
+if [ $? -eq 0 ]; then
+    echo $RESULT | grep "Version" | grep "1" | grep "0x0"
+    if [ $? -ne 0 ]; then
+        echo "Printing wrong version number"
+        exit 99
+    fi
+fi
+rm -f tmp.cert
 
 echo "Done"
 exit 0


### PR DESCRIPTION
Depends on https://github.com/wolfSSL/wolfssl/pull/8136

# Testing
```
$ cd wolfssl
$ ./configure --enable-wolfclu
$ make all check
$ sudo make install
$cd ../wolfCLU
$ ./configure (all tried with CFLAG=-DNO_WOLFSSL_REQ_PRINT) 
$ make all
$ ./wolfssl -genkey rsa -size 2048 -out temp.key -outform pem  -output KEYPAIR
$ ./wolfssl req -new -days 1095 -config csr.conf -key temp.key.priv -out service.csr  -outform PEM -sha256
$ openssl req -in service.csr -text
        Version: 1 (0x0)
$ ./wolfssl req -in service.csr  -noout -text
        Version: 1 (0x0)
```
