### PR TITLE
fix for change to OBJ sn2nid behavior in wolfSSL

### DIFF
--- a/src/tools/clu_funcs.c
+++ b/src/tools/clu_funcs.c
@@ -1221,8 +1221,7 @@ WOLFSSL_X509_NAME* wolfCLU_ParseX509NameString(const char* n, int nSz)
             break;
         }
 
-        tagSz = tagSz + 1; /* include the '=' char */
-        if (tagSz + 2 > (int)sizeof(tag)) { /* +2 for '/' and '\0' chars */
+        if (tagSz + 1 > (int)sizeof(tag)) { /* +1 for null terminator */
             wolfCLU_LogError("found a tag that was too large!");
             wolfSSL_X509_NAME_free(ret);
             ret = NULL;
@@ -1235,12 +1234,12 @@ WOLFSSL_X509_NAME* wolfCLU_ParseX509NameString(const char* n, int nSz)
             break;
         }
         else {
-            XMEMCPY(tag + 1, word, tagSz);
-            tag[tagSz + 1] = '\0'; /* append terminating character */
+            XMEMCPY(tag, word, tagSz);
+            tag[tagSz] = '\0'; /* append terminating character */
         }
 
         if (ret != NULL) {
-            entry = &word[tagSz];
+            entry = &word[tagSz+1];
             nid = wolfSSL_OBJ_sn2nid(tag);
             if (nid == NID_countryName) {
                 encoding = CTC_PRINTABLE;

--- a/tests/x509/x509-ca-test.sh
+++ b/tests/x509/x509-ca-test.sh
@@ -174,7 +174,7 @@ EOF
 touch index.txt
 run_success "ca -h"
 run_success "ca -help"
-run_success "req -key ./certs/server-key.pem -subj O=wolfSSL/C=US/ST=MT/L=Bozeman/CN=wolfSSL/OU=org-unit -out tmp-ca.csr"
+run_success "req -key ./certs/server-key.pem -subj /O=wolfSSL/C=US/ST=MT/L=Bozeman/CN=wolfSSL/OU=org-unit -out tmp-ca.csr"
 
 # testing reading bad conf file
 run_fail "ca -config ca-example.conf -in tmp-ca.csr -out tmp.pem -md sha256 -selfsign -keyfile ./certs/ca-key.pem"


### PR DESCRIPTION
Fixes wolfCLU to use the API OBJ_sn2nid correctly after the change in wolfSSL here (https://github.com/wolfSSL/wolfssl/pull/8324)