### PR TITLE
Fix build errors in server.c

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2226,7 +2226,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             if (myoptarg != NULL) {
                 if (XSTRLEN(myoptarg) >= DTLS_CID_BUFFER_SIZE) {
                     fprintf(stderr, "provided connection ID is too big\n");
-                    return BAD_FUNC_ARG;
+                    XEXIT_T(EXIT_FAILURE);
                 }
                 else {
                     strcpy(dtlsCID, myoptarg);
@@ -3427,10 +3427,11 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         unsigned int receivedCIDSz;
         printf("CID extension was negotiated\n");
         ret = wolfSSL_dtls_cid_get_tx_size(ssl, &receivedCIDSz);
-        if (ret != WOLFSSL_SUCCESS)
+        if (ret != WOLFSSL_SUCCESS) {
             release(ctx, ssl, "Can't get negotiated DTLS CID size");
             ((func_args*)args)->return_code = ret;
             goto exit;
+        }
 
         if (receivedCIDSz > 0) {
             ret = wolfSSL_dtls_cid_get_tx(ssl, receivedCID,


### PR DESCRIPTION
Fixes build errors when wolfSSL is configured with `--enable-all`

```
src/server/server.c: In function ‘server_test’:
src/server/server.c:2229:28: error: returning ‘int’ from a function with return type ‘THREAD_RETURN’ {aka ‘void *’} makes pointer from integer without a cast [-Werror=int-conversion]
 2229 |                     return BAD_FUNC_ARG;
      |                            ^~~~~~~~~~~~
src/server/server.c:3430:9: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
 3430 |         if (ret != WOLFSSL_SUCCESS)
      |         ^~
src/server/server.c:3432:13: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
 3432 |             ((func_args*)args)->return_code = ret;
      |             ^
```