### PR TITLE
fix client and server KEM macro

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -642,7 +642,7 @@ static void SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519,
         } while (ret == WC_PENDING_E);
     #endif
     }
-    #ifdef HAVE_PQC
+    #if defined(HAVE_PQC) && defined(WOLFSSL_MLKEM_KYBER)
     if (onlyKeyShare == 0 || onlyKeyShare == 3) {
         if (usePqc) {
             int group = 0;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -682,7 +682,7 @@ static int SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519,
     #endif
         }
         else if (usePqc == 1) {
-    #ifdef HAVE_PQC
+    #if defined(HAVE_PQC) && defined(WOLFSSL_MLKEM_KYBER)
             groups[count] = 0;
             if (XSTRCMP(pqcAlg, "KYBER_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_KYBER_LEVEL1;

--- a/tests/x509/x509-req-test.sh
+++ b/tests/x509/x509-req-test.sh
@@ -129,7 +129,7 @@ run_success "req -new -key ./certs/server-key.pem -config ./test-prompt.conf -ou
 run_success "req -text -in tmp.csr"
 SUBJECT=`./wolfssl req -in tmp.csr -text | grep -A1 "X509v3 Subject Alternative Name"`
 EXPECTED="        X509v3 Subject Alternative Name: 
-            email:facts@wolfssl.com, Registered ID:1.1.1.1, Registered ID:surname, URI:facts@wolfssl.com"
+            email:facts@wolfssl.com, URI:facts@wolfssl.com, Registered ID:surname, Registered ID:1.1.1.1"
 if [ "$SUBJECT" != "$EXPECTED" ]
 then
     echo "found unexpected result"


### PR DESCRIPTION
Fix server and client build error when build wolfSSL with --enable-kyber or --enable-mldsa.