### PR TITLE
Fixed problems with string init of array

### DIFF
--- a/src/genkey/clu_genkey.c
+++ b/src/genkey/clu_genkey.c
@@ -40,8 +40,8 @@ int wolfCLU_genKey_ED25519(WC_RNG* rng, char* fOutNm, int directive, int format)
     int fOutNmSz;                        /* file name without append */
     int fOutNmAppendSz = 6;              /* # of bytes to append to file name */
     int flagOutputPub = 0;               /* set if outputting both priv/pub */
-    char privAppend[6] = ".priv\0";      /* last part of the priv file name */
-    char pubAppend[6] = ".pub\0\0";      /* last part of the pub file name*/
+    char privAppend[6] = ".priv";        /* last part of the priv file name */
+    char pubAppend[6] = ".pub";          /* last part of the pub file name*/
     byte privKeyBuf[ED25519_KEY_SIZE*2]; /* will hold public & private parts */
     byte pubKeyBuf[ED25519_KEY_SIZE];    /* holds just the public key part */
     word32 privKeySz;                    /* size of private key */
@@ -611,8 +611,8 @@ int wolfCLU_GenAndOutput_ECC(WC_RNG* rng, char* fName, int directive,
 #ifdef HAVE_ECC
     int   fNameSz;
     int   fExtSz      = 6;
-    char  fExtPriv[6] = ".priv\0";
-    char  fExtPub[6]  = ".pub\0\0";
+    char  fExtPriv[6] = ".priv";
+    char  fExtPub[6]  = ".pub";
     char* fOutNameBuf = NULL;
 
     WOLFSSL_BIO *bioPub = NULL;
@@ -790,8 +790,8 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
     int   ret = WOLFCLU_SUCCESS;       /* return value */
     int   fNameSz;                     /* file name without append */
     int   fExtSz       = 6;            /* number of bytes to append to file name */
-    char  fExtPriv[6]  = ".priv\0";    /* last part of the priv file name */
-    char  fExtPub[6]   = ".pub\0\0";   /* last part of the pub file name*/
+    char  fExtPriv[6]  = ".priv";      /* last part of the priv file name */
+    char  fExtPub[6]   = ".pub";       /* last part of the pub file name*/
     char* fOutNameBuf  = NULL;         /* file name + fExt */
     int   flagOutputPub = 0;           /* set if outputting both priv/pub */
     byte* derBuf       = NULL;         /* buffer for DER format */
@@ -1044,8 +1044,8 @@ int wolfCLU_genKey_Dilithium(WC_RNG* rng, char* fName, int directive, int fmt,
     XFILE  file = NULL;
     int   fNameSz     = 0;
     int   fExtSz      = 6;  // size of ".priv\0" or ".pub\0\0"
-    char  fExtPriv[6] = ".priv\0";
-    char  fExtPub[6]  = ".pub\0\0";
+    char  fExtPriv[6] = ".priv";
+    char  fExtPub[6]  = ".pub";
     char* fOutNameBuf = NULL;
 
     #ifdef NO_AES
@@ -1403,8 +1403,8 @@ int wolfCLU_genKey_XMSS(WC_RNG* rng, char* fName,
     int ret            = 0;
     int fNameSz        = 0;           /* file name without append         */
     int fExtSz         = 6;           /* size of ".priv\0" and ".pub\0\0" */
-    char fExtPriv[6]   = ".priv\0";
-    char fExtPub[6]    = ".pub\0\0";
+    char fExtPriv[6]   = ".priv";
+    char fExtPub[6]    = ".pub";
     char* fOutNameBuf  = NULL;        /* file name + fExt       */
     XFILE file         = NULL;        /* public key file        */
     byte* pubOutBuf    = NULL;        /* public key buffer      */

--- a/src/genkey/clu_genkey_setup.c
+++ b/src/genkey/clu_genkey_setup.c
@@ -29,7 +29,7 @@ int wolfCLU_genKeySetup(int argc, char** argv)
 {
 #ifndef WOLFCLU_NO_FILESYSTEM
     char     keyOutFName[MAX_FILENAME_SZ];  /* default outFile for genKey */
-    char     defaultFormat[4] = "der\0";
+    char     defaultFormat[4] = "der";
     WC_RNG   rng;
 
     char*    keyType = NULL;       /* keyType */


### PR DESCRIPTION
Some arrays have strings used to initialize them with explicit null terminators as padding. This padding method causes gcc to throw warnings so I removed it. Conforming C compilers should automatically fill the rest of the array slots with null terminators.

my compiler info:
gcc version 15.1.1 20250425 (Red Hat 15.1.1-1) (GCC)