### PR TITLE
Improve x509-req-test.sh

### DIFF
--- a/tests/x509/x509-req-test.sh
+++ b/tests/x509/x509-req-test.sh
@@ -43,7 +43,7 @@ run_fail() {
 }
 
 
-cat << EOF >> test.conf
+cat << EOF > test.conf
 [ req ]
 distinguished_name =req_distinguished_name
 attributes =req_attributes
@@ -90,7 +90,7 @@ DNS.9 = thirdName
 DNS.10 = tenthName
 EOF
 
-cat << EOF >> test-prompt.conf
+cat << EOF > test-prompt.conf
 [ req ]
 distinguished_name =req_distinguished_name
 attributes =req_attributes


### PR DESCRIPTION
## Description

This PR improves the `x509-req-test.sh` not to keep wrong error status unintentionally, after an error happens.

The script will add configurations to `test-prompt.conf` and `test.conf` while running.
Once the script stopped in the middle, those files are un-removed, and wrong configuration file which has duplicated contents will be generated at next run.
This PR changes from "add" to "create" for the configuration files.

## Test

wolfSSL v5.8.2:
./configure --enable-wolfclu && make install

wolfCLU:
./configure && make check