### PR TITLE
F-644: fix read of exactly MAX_LEN bytes treated as error

### DIFF
--- a/src/crypto/clu_decrypt.c
+++ b/src/crypto/clu_decrypt.c
@@ -156,7 +156,7 @@ int wolfCLU_decrypt(int alg, char* mode, byte* pwdKey, byte* key, int size,
             }
             else {
                 ret = (int)XFREAD(input, 1, MAX_LEN, inFile);
-                if ((ret > 0 && ret != MAX_LEN) || feof(inFile)) {
+                if (ret > 0) {
                     tempMax = ret;
                     ret = 0; /* success */
                 }

--- a/src/crypto/clu_decrypt.c
+++ b/src/crypto/clu_decrypt.c
@@ -161,7 +161,12 @@ int wolfCLU_decrypt(int alg, char* mode, byte* pwdKey, byte* key, int size,
                     ret = 0; /* success */
                 }
                 else {
-                    wolfCLU_LogError("Input file does not exist.");
+                    if (feof(inFile)) {
+                        wolfCLU_LogError("Unexpected end of file.");
+                    }
+                    else {
+                        wolfCLU_LogError("File read error.");
+                    }
                     ret = FREAD_ERROR;
                 }
             }

--- a/tests/encrypt/enc-test.sh
+++ b/tests/encrypt/enc-test.sh
@@ -185,5 +185,28 @@ fi
 rm -f test-dec.der
 rm -f test-enc.der
 
+# camellia: decrypt file larger than MAX_LEN (non-EVP path)
+if grep -q "HAVE_CAMELLIA" wolfssl/wolfssl/options.h 2>/dev/null; then
+    dd if=/dev/urandom bs=2048 count=1 of=test_maxlen_camellia.bin 2>/dev/null
+    ./wolfssl encrypt camellia-cbc-128 -pwd testpwd \
+        -in test_maxlen_camellia.bin -out test_maxlen_camellia.enc
+    if [ $? != 0 ]; then
+        echo "failed to encrypt in MAX_LEN boundary test"
+        exit 99
+    fi
+    ./wolfssl decrypt camellia-cbc-128 \
+        -in test_maxlen_camellia.enc -out test_maxlen_camellia.dec -pwd testpwd
+    if [ $? != 0 ]; then
+        echo "failed to decrypt in MAX_LEN boundary test"
+        exit 99
+    fi
+    diff test_maxlen_camellia.bin test_maxlen_camellia.dec &> /dev/null
+    if [ $? != 0 ]; then
+        echo "MAX_LEN boundary: decrypted file does not match original"
+        exit 99
+    fi
+    rm -f test_maxlen_camellia.bin test_maxlen_camellia.enc test_maxlen_camellia.dec
+fi
+
 echo "Done"
 exit 0

--- a/tests/encrypt/enc-test.sh
+++ b/tests/encrypt/enc-test.sh
@@ -185,7 +185,8 @@ fi
 rm -f test-dec.der
 rm -f test-enc.der
 
-# camellia: decrypt file of exactly MAX_LEN bytes (non-EVP path)
+# camellia: decrypt file whose size is a multiple of MAX_LEN (2 x 1024 bytes)
+# to ensure the exact-boundary read case is covered (non-EVP path)
 if grep -q "HAVE_CAMELLIA" wolfssl/wolfssl/options.h 2>/dev/null; then
     dd if=/dev/urandom bs=2048 count=1 of=test_maxlen_camellia.bin 2>/dev/null
     ./wolfssl encrypt camellia-cbc-128 -pwd testpwd \

--- a/tests/encrypt/enc-test.sh
+++ b/tests/encrypt/enc-test.sh
@@ -185,7 +185,7 @@ fi
 rm -f test-dec.der
 rm -f test-enc.der
 
-# camellia: decrypt file larger than MAX_LEN (non-EVP path)
+# camellia: decrypt file of exactly MAX_LEN bytes (non-EVP path)
 if grep -q "HAVE_CAMELLIA" wolfssl/wolfssl/options.h 2>/dev/null; then
     dd if=/dev/urandom bs=2048 count=1 of=test_maxlen_camellia.bin 2>/dev/null
     ./wolfssl encrypt camellia-cbc-128 -pwd testpwd \


### PR DESCRIPTION
Fix "Successful read of exactly MAX_LEN bytes treated as error"
Add test coverage

Depend on : #211 (Fixed)
Depend on : #219 