### PR TITLE
F 1483 : Fix SHA-1 prefix match overwriting SHA-256/384/512 output

### DIFF
--- a/src/hash/clu_hash.c
+++ b/src/hash/clu_hash.c
@@ -101,22 +101,22 @@ int wolfCLU_hash(WOLFSSL_BIO* bioIn, WOLFSSL_BIO* bioOut, const char* alg,
 
     /* hashes using accepted algorithm */
 #ifndef NO_MD5
-    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "md5", 3) == 0) {
+    if (ret == WOLFCLU_SUCCESS && XSTRCMP(alg, "md5") == 0) {
         ret = wc_Md5Hash(input, inputSz, output);
     }
 #endif
 #ifndef NO_SHA256
-    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "sha256", 6) == 0) {
+    if (ret == WOLFCLU_SUCCESS && XSTRCMP(alg, "sha256") == 0) {
         ret = wc_Sha256Hash(input, inputSz, output);
     }
 #endif
 #ifdef WOLFSSL_SHA384
-    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "sha384", 6) == 0) {
+    if (ret == WOLFCLU_SUCCESS && XSTRCMP(alg, "sha384") == 0) {
         ret = wc_Sha384Hash(input, inputSz, output);
     }
 #endif
 #ifdef WOLFSSL_SHA512
-    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "sha512", 6) == 0) {
+    if (ret == WOLFCLU_SUCCESS && XSTRCMP(alg, "sha512") == 0) {
         ret = wc_Sha512Hash(input, inputSz, output);
     }
 #endif
@@ -126,7 +126,7 @@ int wolfCLU_hash(WOLFSSL_BIO* bioIn, WOLFSSL_BIO* bioOut, const char* alg,
     }
 #endif
 #ifdef HAVE_BLAKE2
-    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "blake2b", 7) == 0) {
+    if (ret == WOLFCLU_SUCCESS && XSTRCMP(alg, "blake2b") == 0) {
         ret = wc_InitBlake2b(&hash, size);
         if (ret != 0) return ret;
         ret = wc_Blake2bUpdate(&hash, input, inputSz);
@@ -138,11 +138,11 @@ int wolfCLU_hash(WOLFSSL_BIO* bioIn, WOLFSSL_BIO* bioOut, const char* alg,
 
 #ifndef NO_CODING
 #ifdef WOLFSSL_BASE64_ENCODE
-    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "base64enc", 9) == 0) {
+    if (ret == WOLFCLU_SUCCESS && XSTRCMP(alg, "base64enc") == 0) {
         ret = Base64_Encode(input, inputSz, output, (word32*)&size);
     }
 #endif /* WOLFSSL_BASE64_ENCODE */
-    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "base64dec", 9) == 0) {
+    if (ret == WOLFCLU_SUCCESS && XSTRCMP(alg, "base64dec") == 0) {
         ret = Base64_Decode(input, inputSz, output, (word32*)&size);
     }
 #endif /* !NO_CODING */

--- a/src/hash/clu_hash.c
+++ b/src/hash/clu_hash.c
@@ -121,7 +121,8 @@ int wolfCLU_hash(WOLFSSL_BIO* bioIn, WOLFSSL_BIO* bioOut, const char* alg,
     }
 #endif
 #ifndef NO_SHA
-    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "sha", 3) == 0) {
+    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "sha", 3) == 0
+            && XSTRLEN(alg) == 3) {
         ret = wc_ShaHash(input, inputSz, output);
     }
 #endif

--- a/src/hash/clu_hash.c
+++ b/src/hash/clu_hash.c
@@ -121,8 +121,7 @@ int wolfCLU_hash(WOLFSSL_BIO* bioIn, WOLFSSL_BIO* bioOut, const char* alg,
     }
 #endif
 #ifndef NO_SHA
-    if (ret == WOLFCLU_SUCCESS && XSTRNCMP(alg, "sha", 3) == 0
-            && XSTRLEN(alg) == 3) {
+    if (ret == WOLFCLU_SUCCESS && XSTRCMP(alg, "sha") == 0) {
         ret = wc_ShaHash(input, inputSz, output);
     }
 #endif

--- a/src/hash/clu_hash_setup.c
+++ b/src/hash/clu_hash_setup.c
@@ -140,7 +140,7 @@ int wolfCLU_hashSetup(int argc, char** argv)
 #endif
 
 #ifndef NO_SHA
-    if ((XSTRNCMP(alg, "sha", 3) == 0) && (XSTRLEN(alg) == 3))
+    if (XSTRCMP(alg, "sha") == 0)
         size = WC_SHA_DIGEST_SIZE;
 #endif
 

--- a/src/hash/clu_hash_setup.c
+++ b/src/hash/clu_hash_setup.c
@@ -135,7 +135,7 @@ int wolfCLU_hashSetup(int argc, char** argv)
 
     /* sets default size of algorithm */
 #ifndef NO_MD5
-    if (XSTRNCMP(alg, "md5", 3) == 0)
+    if (XSTRCMP(alg, "md5") == 0)
         size = WC_MD5_DIGEST_SIZE;
 #endif
 
@@ -145,17 +145,17 @@ int wolfCLU_hashSetup(int argc, char** argv)
 #endif
 
 #ifndef NO_SHA256
-    if (XSTRNCMP(alg, "sha256", 6) == 0)
+    if (XSTRCMP(alg, "sha256") == 0)
         size = WC_SHA256_DIGEST_SIZE;
 #endif
 
 #ifdef WOLFSSL_SHA384
-    if (XSTRNCMP(alg, "sha384", 6) == 0)
+    if (XSTRCMP(alg, "sha384") == 0)
         size = WC_SHA384_DIGEST_SIZE;
 #endif
 
 #ifdef WOLFSSL_SHA512
-    if (XSTRNCMP(alg, "sha512", 6) == 0)
+    if (XSTRCMP(alg, "sha512") == 0)
         size = WC_SHA512_DIGEST_SIZE;
 #endif
 

--- a/src/hash/clu_hash_setup.c
+++ b/src/hash/clu_hash_setup.c
@@ -81,7 +81,7 @@ int wolfCLU_hashSetup(int argc, char** argv)
 
     for (i = 0; i < (int)algsSz; ++i) {
         /* checks for acceptable algorithms */
-        if (XSTRNCMP(argv[2], algs[i], XSTRLEN(algs[i])) == 0) {
+        if (XSTRCMP(argv[2], algs[i]) == 0) {
             alg = argv[2];
             algCheck = 1;
         }
@@ -140,7 +140,7 @@ int wolfCLU_hashSetup(int argc, char** argv)
 #endif
 
 #ifndef NO_SHA
-    if (XSTRNCMP(alg, "sha", 3) == 0)
+    if ((XSTRNCMP(alg, "sha", 3) == 0) && (XSTRLEN(alg) == 3))
         size = WC_SHA_DIGEST_SIZE;
 #endif
 


### PR DESCRIPTION
## Summary
- `XSTRNCMP(alg, "sha", 3)` in `wolfCLU_hash` and `wolfCLU_hashSetup`
  matched "sha256", "sha384", and "sha512", causing SHA-1 to overwrite
  the correct digest and size
- Fixed by adding `XSTRLEN(alg) == 3` guard to the SHA-1 branch in
  `clu_hash.c` and `clu_hash_setup.c`
- Fixed `algCheck` loop in `clu_hash_setup.c` to use `XSTRCMP` for
  exact matching instead of prefix matching

Depend on : #211 (Fixed)
Depend on : #219 