### PR TITLE
Fix wolfCLU_sign_data_ecc and wolfCLU_verify_signature_ecc

### DIFF
--- a/src/sign-verify/clu_sign.c
+++ b/src/sign-verify/clu_sign.c
@@ -388,11 +388,34 @@ int wolfCLU_sign_data_ecc(byte* data, char* out, word32 fSz, char* privKey,
         }
     }
     if (ret == 0) {
+        int keySz;
+        enum wc_HashType hashType;
+        int digestSz;
+        byte hashBuf[WC_MAX_DIGEST_SIZE];
+
         XMEMSET(outBuf, 0, outBufSz);
 
-        /* signing input with ecc priv key to produce signature */
-        outLen = (word32)outBufSz;
-        ret = wc_ecc_sign_hash(data, fSz, outBuf, &outLen, &rng, &key);
+        /* hash the input data before signing -- ECDSA signs a digest, not raw
+         * data.  Select a hash whose digest size matches the curve. */
+        keySz = wc_ecc_size(&key);
+        if (keySz <= 32) {
+            hashType = WC_HASH_TYPE_SHA256;
+        }
+        else if (keySz <= 48) {
+            hashType = WC_HASH_TYPE_SHA384;
+        }
+        else {
+            hashType = WC_HASH_TYPE_SHA512;
+        }
+        digestSz = wc_HashGetDigestSize(hashType);
+        ret = wc_Hash(hashType, data, fSz, hashBuf, digestSz);
+
+        /* signing the hash with ecc priv key to produce signature */
+        if (ret == 0) {
+            outLen = (word32)outBufSz;
+            ret = wc_ecc_sign_hash(hashBuf, digestSz, outBuf, &outLen,
+                                   &rng, &key);
+        }
         if (ret >= 0) {
             XFILE s;
             s = XFOPEN(out, "wb");

--- a/src/sign-verify/clu_sign.c
+++ b/src/sign-verify/clu_sign.c
@@ -396,7 +396,8 @@ int wolfCLU_sign_data_ecc(byte* data, char* out, word32 fSz, char* privKey,
         XMEMSET(outBuf, 0, outBufSz);
 
         /* hash the input data before signing -- ECDSA signs a digest, not raw
-         * data.  Select a hash whose digest size matches the curve. */
+         * data.  Select a curve-appropriate hash paired with the curve
+         * strength; ECDSA will truncate the digest as needed. */
         keySz = wc_ecc_size(&key);
         if (keySz <= 32) {
             hashType = WC_HASH_TYPE_SHA256;
@@ -408,7 +409,13 @@ int wolfCLU_sign_data_ecc(byte* data, char* out, word32 fSz, char* privKey,
             hashType = WC_HASH_TYPE_SHA512;
         }
         digestSz = wc_HashGetDigestSize(hashType);
-        ret = wc_Hash(hashType, data, fSz, hashBuf, digestSz);
+        if (digestSz <= 0 || digestSz > WC_MAX_DIGEST_SIZE) {
+            wolfCLU_LogError("Invalid hash digest size: %d", digestSz);
+            ret = BAD_FUNC_ARG;
+        }
+        else {
+            ret = wc_Hash(hashType, data, fSz, hashBuf, digestSz);
+        }
 
         /* signing the hash with ecc priv key to produce signature */
         if (ret == 0) {

--- a/src/sign-verify/clu_verify.c
+++ b/src/sign-verify/clu_verify.c
@@ -566,10 +566,33 @@ int wolfCLU_verify_signature_ecc(byte* sig, int sigSz, byte* hash, int hashSz,
         }
     }
     if (ret == 0) {
+        int keySz;
+        enum wc_HashType hashType;
+        int digestSz;
+        byte hashBuf[WC_MAX_DIGEST_SIZE];
+
         XMEMSET(outBuf, 0, outBufSz);
 
-        /* verify data with Ecc public key */
-        ret = wc_ecc_verify_hash(sig, sigSz, hash, hashSz, &stat, &key);
+        /* hash the input data before verifying -- ECDSA operates on a digest,
+         * not raw data.  Select a hash whose digest size matches the curve. */
+        keySz = wc_ecc_size(&key);
+        if (keySz <= 32) {
+            hashType = WC_HASH_TYPE_SHA256;
+        }
+        else if (keySz <= 48) {
+            hashType = WC_HASH_TYPE_SHA384;
+        }
+        else {
+            hashType = WC_HASH_TYPE_SHA512;
+        }
+        digestSz = wc_HashGetDigestSize(hashType);
+        ret = wc_Hash(hashType, hash, hashSz, hashBuf, digestSz);
+
+        /* verify the hash with Ecc public key */
+        if (ret == 0) {
+            ret = wc_ecc_verify_hash(sig, sigSz, hashBuf, digestSz,
+                                     &stat, &key);
+        }
         if (ret < 0) {
             wolfCLU_LogError("Failed to verify data with pub key.\nRET: %d", ret);
         }

--- a/src/sign-verify/clu_verify.c
+++ b/src/sign-verify/clu_verify.c
@@ -574,7 +574,8 @@ int wolfCLU_verify_signature_ecc(byte* sig, int sigSz, byte* hash, int hashSz,
         XMEMSET(outBuf, 0, outBufSz);
 
         /* hash the input data before verifying -- ECDSA operates on a digest,
-         * not raw data.  Select a hash whose digest size matches the curve. */
+         * not raw data.  Select a curve-appropriate hash paired with the curve
+         * strength; ECDSA will truncate the digest as needed. */
         keySz = wc_ecc_size(&key);
         if (keySz <= 32) {
             hashType = WC_HASH_TYPE_SHA256;
@@ -586,7 +587,12 @@ int wolfCLU_verify_signature_ecc(byte* sig, int sigSz, byte* hash, int hashSz,
             hashType = WC_HASH_TYPE_SHA512;
         }
         digestSz = wc_HashGetDigestSize(hashType);
-        ret = wc_Hash(hashType, hash, hashSz, hashBuf, digestSz);
+        if (digestSz > 0 && digestSz <= WC_MAX_DIGEST_SIZE) {
+            ret = wc_Hash(hashType, hash, hashSz, hashBuf, digestSz);
+        }
+        else {
+            ret = BAD_FUNC_ARG;
+        }
 
         /* verify the hash with Ecc public key */
         if (ret == 0) {

--- a/src/x509/clu_x509_sign.c
+++ b/src/x509/clu_x509_sign.c
@@ -343,7 +343,7 @@ int wolfCLU_GenChimeraCertSign(WOLFSSL_BIO *bioCaKey, WOLFSSL_BIO *bioAltCaKey,
 
     /* open CA ecc private key */
     if (ret == WOLFCLU_SUCCESS) {
-        ret = wolfSSL_BIO_get_fp(bioCaKey, &caKeyFp);
+        ret = (int)wolfSSL_BIO_get_fp(bioCaKey, &caKeyFp);
         if (ret != WOLFCLU_SUCCESS) {
             wolfCLU_LogError("Error cannot get CA key fd");
             ret = WOLFCLU_FATAL_ERROR;
@@ -364,7 +364,7 @@ int wolfCLU_GenChimeraCertSign(WOLFSSL_BIO *bioCaKey, WOLFSSL_BIO *bioAltCaKey,
 
     /* open server ecc private key */
     if (ret == WOLFCLU_SUCCESS && !isCA) {
-        ret = wolfSSL_BIO_get_fp(bioSubjKey, &serverKeyFp);
+        ret = (int)wolfSSL_BIO_get_fp(bioSubjKey, &serverKeyFp);
         if (ret != WOLFCLU_SUCCESS) {
             wolfCLU_LogError("Error cannot get server key fd");
             ret = WOLFCLU_FATAL_ERROR;
@@ -481,7 +481,7 @@ int wolfCLU_GenChimeraCertSign(WOLFSSL_BIO *bioCaKey, WOLFSSL_BIO *bioAltCaKey,
 
     /* load alternative CA public key */
     if (ret == WOLFCLU_SUCCESS) {
-        ret = wolfSSL_BIO_get_fp(bioAltSubjPubKey, &altCaPubKeyFp);
+        ret = (int)wolfSSL_BIO_get_fp(bioAltSubjPubKey, &altCaPubKeyFp);
         if (ret != WOLFCLU_SUCCESS) {
             wolfCLU_LogError("Error get AltCAkey fd");
             ret = WOLFCLU_FATAL_ERROR;
@@ -530,7 +530,7 @@ int wolfCLU_GenChimeraCertSign(WOLFSSL_BIO *bioCaKey, WOLFSSL_BIO *bioAltCaKey,
     }
 
     if (ret == WOLFCLU_SUCCESS) {
-        ret = wolfSSL_BIO_get_fp(bioAltCaKey, &altCaKeyFp);
+        ret = (int)wolfSSL_BIO_get_fp(bioAltCaKey, &altCaKeyFp);
         if (ret != WOLFCLU_SUCCESS) {
             wolfCLU_LogError("Error cannot get AltCA key fd");
             ret = WOLFCLU_FATAL_ERROR;


### PR DESCRIPTION
src/sign-verify/clu_sign.c — wolfCLU_sign_data_ecc():
Before calling wc_ecc_sign_hash(), the input data is now hashed with a curve-appropriate algorithm (SHA-256 for P-256, SHA-384 for P-384, SHA-512 for P-521+). The digest is passed to wc_ecc_sign_hash() instead of the raw file contents.
                                                                              
src/sign-verify/clu_verify.c — wolfCLU_verify_signature_ecc() :
Same treatment — the raw message is hashed before being passed to wc_ecc_verify_hash(), using the same curve-size-based hash selection so sign and verify are consistent.

Fix some build errors with clang