### PR TITLE
F-580 zeroed out password field at end of function

### DIFF
--- a/src/pkey/clu_rsa.c
+++ b/src/pkey/clu_rsa.c
@@ -137,6 +137,7 @@ int wolfCLU_RSA(int argc, char** argv)
 
             case WOLFCLU_HELP:
                 wolfCLU_RSAHelp();
+                wolfCLU_ForceZero(password, MAX_PASSWORD_SIZE);
                 return WOLFCLU_SUCCESS;
 
             case ':':
@@ -295,6 +296,7 @@ int wolfCLU_RSA(int argc, char** argv)
         }
     }
 
+    wolfCLU_ForceZero(password, MAX_PASSWORD_SIZE);
     wolfSSL_BIO_free(bioIn);
     wolfSSL_BIO_free(bioOut);
     wolfSSL_RSA_free(rsa);


### PR DESCRIPTION
password field was not zeroed out in the wolfCLU_RSA function before the function returned now it is but calling wolfCLU_ForceZero on the char array.