### PR TITLE
Fix heap over read

### DIFF
--- a/src/tools/clu_funcs.c
+++ b/src/tools/clu_funcs.c
@@ -1305,11 +1305,10 @@ WOLFSSL_X509_NAME* wolfCLU_ParseX509NameString(const char* n, int nSz)
         wolfCLU_LogError("error allocating name structure");
         return NULL;
     }
-
     for (word = strtok_r((char*)n, deli, &end); word != NULL;
             word = strtok_r(NULL, deli, &end)) {
         tagSz = (int)strcspn(word, "=");
-        if (tagSz <= 0) {
+        if (tagSz <= 0 || word[tagSz] != '=') {
             wolfCLU_LogError("error finding '=' char in name");
             wolfSSL_X509_NAME_free(ret);
             ret = NULL;

--- a/src/x509/clu_request_setup.c
+++ b/src/x509/clu_request_setup.c
@@ -865,9 +865,13 @@ int wolfCLU_requestSetup(int argc, char** argv)
         if (name != NULL) {
             wolfSSL_X509_REQ_set_subject_name(x509, name);
             wolfSSL_X509_NAME_free(name);
+            reSign = 1; /* re-sign after subject change */
         }
-
-        reSign = 1; /* re-sign after subject change */
+        else {
+            wolfCLU_LogError("Failed to parse -subj string");
+            wolfCLU_certgenHelp();
+            ret = USER_INPUT_ERROR;
+        }
     }
 
     /* if no configure is passed in then get input from command line */

--- a/tests/x509/x509-process-test.py
+++ b/tests/x509/x509-process-test.py
@@ -504,6 +504,20 @@ class TestX509ProcessInvalidFiles(unittest.TestCase):
         self.assertNotEqual(r.returncode, 0)
 
 
+class TestMalformedArguments(unittest.TestCase):
+    """ Regression: for malformed arguments """
+
+    def test_5a_malformed_subj_argument(self):
+        """ malformed string passed to -subj should result in error and
+        logging of issue """
+        r = run_wolfssl("req", "-new", "-days", "3650",
+                        "-key", os.path.join(CERTS_DIR, "server-key.pem"),
+                        "-subj",
+                        "/O=wolfSSL/C=US/ST=WA/L=Seattle/CN=wolfSSL/OUorg-unit")
+        self.assertNotEqual(r.returncode, 0, r.stderr)
+        self.assertGreater(len(r.stderr), 0)
+
+
 class TestX509ModulusNoout(unittest.TestCase):
     """Regression: x509 -modulus -noout must not crash."""
 


### PR DESCRIPTION
x509 name can look like this /CN=name/C=company the parsing function did not account for strings that had missing = at the end of the string /CN=name/Ccompany. This caused an issue where the parsing logic would attempt to access one passed the last byte of the string. There is now logic to explicitly catch when this is the case. 