### PR TITLE
Fail non-zero on verify failures; fix stdin keySize clobber (F-5362/F-5363/F-5970)

### DIFF
--- a/src/crypto/clu_crypto_setup.c
+++ b/src/crypto/clu_crypto_setup.c
@@ -537,11 +537,11 @@ int wolfCLU_setup(int argc, char** argv, char action)
              * wolfCLU_GetStdinPassword writes the entered length back through
              * this pointer, and keySize (the algorithm key size in bits) is
              * still needed for key derivation and cleanup below. */
-            int pwdBufSz = keySize + block;
+            word32 pwdBufSz = (word32)(keySize + block);
             WOLFCLU_LOG(WOLFCLU_L0,
                     "No -pwd flag set, please enter a password to use for"
                     " encrypting.");
-            ret = wolfCLU_GetStdinPassword(pwdKey, (word32*)&pwdBufSz);
+            ret = wolfCLU_GetStdinPassword(pwdKey, &pwdBufSz);
             pwdKeyChk = 1;
         }
     }

--- a/src/crypto/clu_crypto_setup.c
+++ b/src/crypto/clu_crypto_setup.c
@@ -533,10 +533,15 @@ int wolfCLU_setup(int argc, char** argv, char action)
         }
         /* if no pwdKey is provided */
         else {
+            /* Pass the pwdKey buffer capacity, NOT &keySize:
+             * wolfCLU_GetStdinPassword writes the entered length back through
+             * this pointer, and keySize (the algorithm key size in bits) is
+             * still needed for key derivation and cleanup below. */
+            int pwdBufSz = keySize + block;
             WOLFCLU_LOG(WOLFCLU_L0,
                     "No -pwd flag set, please enter a password to use for"
                     " encrypting.");
-            ret = wolfCLU_GetStdinPassword(pwdKey, (word32*)&keySize);
+            ret = wolfCLU_GetStdinPassword(pwdKey, (word32*)&pwdBufSz);
             pwdKeyChk = 1;
         }
     }
@@ -649,10 +654,12 @@ int wolfCLU_setup(int argc, char** argv, char action)
     }
     /* clear and free data — zero the full allocation, not just the
      * keyBytes actually used, so any future code path that writes past
-     * the cipher key length doesn't leak material across XFREE. */
-    XMEMSET(key, 0, keySize);
-    XMEMSET(pwdKey, 0, keySize + block);
-    XMEMSET(iv, 0, block);
+     * the cipher key length doesn't leak material across XFREE.
+     * ForceZero (not XMEMSET) so the compiler can't drop the wipe of these
+     * soon-to-be-freed key buffers. */
+    wolfCLU_ForceZero(key, keySize);
+    wolfCLU_ForceZero(pwdKey, keySize + block);
+    wolfCLU_ForceZero(iv, block);
     wolfCLU_freeBins(pwdKey, iv, key, NULL, NULL);
 
     if (mode != NULL)

--- a/src/sign-verify/clu_verify.c
+++ b/src/sign-verify/clu_verify.c
@@ -516,6 +516,7 @@ int wolfCLU_verify_signature_ecc(byte* sig, int sigSz, byte* hash, int hashSz,
         }
         else {
             wolfCLU_LogError("Invalid Signature.");
+            ret = WOLFCLU_FATAL_ERROR;
         }
     }
 
@@ -651,6 +652,7 @@ int wolfCLU_verify_signature_ed25519(byte* sig, int sigSz,
         }
         else {
             wolfCLU_LogError("Invalid Signature.");
+            ret = WOLFCLU_FATAL_ERROR;
         }
     }
 
@@ -795,6 +797,7 @@ int wolfCLU_verify_signature_dilithium(byte* sig, int sigSz, byte* msg,
     }
     else {
         wolfCLU_LogError("Invalid Signature.");
+        ret = WOLFCLU_FATAL_ERROR;
     }
     wc_dilithium_free(key);
 
@@ -802,7 +805,7 @@ int wolfCLU_verify_signature_dilithium(byte* sig, int sigSz, byte* msg,
     XFREE(key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
-    return WOLFCLU_SUCCESS;
+    return (ret >= 0) ? WOLFCLU_SUCCESS : ret;
 #else
     (void)sig;
     (void)sigSz;

--- a/src/x509/clu_request_setup.c
+++ b/src/x509/clu_request_setup.c
@@ -1028,6 +1028,7 @@ int wolfCLU_requestSetup(int argc, char** argv)
             }
             else {
                 wolfCLU_LogError("verify failed");
+                ret = WOLFCLU_FATAL_ERROR;
             }
         }
     }

--- a/tests/encrypt/enc-test.py
+++ b/tests/encrypt/enc-test.py
@@ -3,13 +3,24 @@
 
 import filecmp
 import os
+import re
 import shutil
 import subprocess
 import sys
+import time
 import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from wolfclu_test import CERTS_DIR, WOLFSSL_BIN, run_wolfssl, test_main
+
+# The interactive password prompt only reads from stdin when stdin is a real
+# terminal (wolfCLU_GetStdinPassword -> tcgetattr fails on a pipe), so driving
+# it requires a pseudo-terminal. The pty module is POSIX-only.
+try:
+    import pty as _pty
+    HAVE_PTY = True
+except ImportError:
+    HAVE_PTY = False
 
 
 def run_enc(*args, password=""):
@@ -816,6 +827,187 @@ class EncKeyInputTest(unittest.TestCase):
                          + r.stderr)
         self.assertTrue(filecmp.cmp(self._orig(), dec, shallow=False),
                         "rand-hex -> -inkey workflow did not round-trip")
+
+
+@unittest.skipUnless(HAVE_PTY, "pty not available (non-POSIX)")
+class EncStdinPasswordTest(unittest.TestCase):
+    """Interactive stdin-password path of `encrypt` (F-5970).
+
+    Running `encrypt` without -pwd/-pass/-key prompts for a password on the
+    terminal via wolfCLU_GetStdinPassword, which writes the typed length back
+    through its size pointer. The caller passed &keySize (the algorithm key
+    size in bits), so keySize was overwritten by the password length. With
+    -pbkdf2 the EVP derivation length is (keySize+7)/8, collapsing the derived
+    key to a couple of bytes. These tests drive the prompt over a pty.
+    """
+
+    # Any human-length password truncates the bit-size keySize well below a
+    # real cipher key, so the derived key collapses to 1-2 bytes when buggy.
+    PASSWORD = "correcthorse"
+    PLAINTEXT = b"F-5970 interactive password regression payload\n"
+    # AES-256 key length in bytes.
+    FULL_KEY_BYTES = 32
+
+    @classmethod
+    def setUpClass(cls):
+        config_log = os.path.join(".", "config.log")
+        if os.path.isfile(config_log):
+            with open(config_log) as f:
+                if "disable-filesystem" in f.read():
+                    raise unittest.SkipTest("filesystem support disabled")
+
+    def _cleanup(self, *files):
+        for f in files:
+            self.addCleanup(lambda p=f: os.remove(p)
+                            if os.path.exists(p) else None)
+
+    def _write_plaintext(self, path):
+        with open(path, "wb") as f:
+            f.write(self.PLAINTEXT)
+
+    def _encrypt_with_pty_password(self, password, *args, timeout=30):
+        """Run `wolfssl encrypt <args>` and type `password` at the prompt over
+        a pseudo-terminal. Returns (exit_code, combined_output)."""
+        import select
+        import signal
+
+        # fgets() reads a line, so the password must be newline-terminated or
+        # the child blocks forever waiting for end-of-line.
+        line = (password + "\n").encode()
+        argv = [WOLFSSL_BIN, "encrypt"] + list(args)
+        pid, fd = _pty.fork()
+        if pid == 0:
+            # Child: become the encrypt process with the pty as its stdin.
+            try:
+                os.execvpe(argv[0], argv, os.environ)
+            except Exception:
+                pass
+            os._exit(127)
+
+        output = b""
+        wrote = False
+        deadline = time.time() + timeout
+        try:
+            while time.time() < deadline:
+                r, _, _ = select.select([fd], [], [], 0.5)
+                if fd in r:
+                    try:
+                        data = os.read(fd, 1024)
+                    except OSError:
+                        break  # slave closed (child exited)
+                    if not data:
+                        break
+                    output += data
+                    if not wrote and b"Input Password" in output:
+                        os.write(fd, line)
+                        wrote = True
+                elif not wrote:
+                    # Prompt may not have matched yet; send it anyway.
+                    os.write(fd, line)
+                    wrote = True
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+        # Reap with a bounded wait so a stuck child cannot hang the suite.
+        end = time.time() + 5
+        status = None
+        while time.time() < end:
+            wpid, st = os.waitpid(pid, os.WNOHANG)
+            if wpid == pid:
+                status = st
+                break
+            time.sleep(0.05)
+        if status is None:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+            _, status = os.waitpid(pid, 0)
+
+        if os.WIFEXITED(status):
+            code = os.WEXITSTATUS(status)
+        elif os.WIFSIGNALED(status):
+            code = -os.WTERMSIG(status)
+        else:
+            code = -1
+        return code, output.decode(errors="replace")
+
+    def test_pbkdf2_full_key_derivation(self):
+        """A typed password with -pbkdf2 must derive the full cipher key.
+
+        Before the fix keySize was overwritten by the password length, so the
+        `-p` debug print reported a 1-2 byte key instead of 32."""
+        plain = "f5970_keylen_in.txt"
+        cipher = "f5970_keylen.bin"
+        self._cleanup(plain, cipher)
+        self._write_plaintext(plain)
+
+        code, out = self._encrypt_with_pty_password(
+            self.PASSWORD, "aes-cbc-256", "-pbkdf2", "-p",
+            "-in", plain, "-out", cipher)
+        self.assertEqual(code, 0, "encrypt failed: " + out)
+
+        m = re.search(r"key\s*\[(\d+)\]", out)
+        self.assertIsNotNone(m, "no key length in debug output: " + out)
+        self.assertEqual(int(m.group(1)), self.FULL_KEY_BYTES,
+                         "AES-256 key derived as {} bytes, expected {} "
+                         "(keySize was clobbered)".format(
+                             m.group(1), self.FULL_KEY_BYTES))
+
+    def test_pbkdf2_stdin_decrypts_with_pass(self):
+        """A file encrypted with a typed password + -pbkdf2 must decrypt with
+        the same password supplied via -pass (interoperability, F-5970)."""
+        plain = "f5970_interop_in.txt"
+        cipher = "f5970_interop.bin"
+        dec = "f5970_interop_out.txt"
+        self._cleanup(plain, cipher, dec)
+        self._write_plaintext(plain)
+
+        code, out = self._encrypt_with_pty_password(
+            self.PASSWORD, "aes-cbc-256", "-pbkdf2",
+            "-in", plain, "-out", cipher)
+        self.assertEqual(code, 0, "encrypt failed: " + out)
+
+        r = subprocess.run(
+            [WOLFSSL_BIN, "decrypt", "aes-cbc-256", "-pbkdf2",
+             "-pass", "pass:" + self.PASSWORD, "-in", cipher, "-out", dec],
+            capture_output=True, text=True, stdin=subprocess.DEVNULL,
+            timeout=60)
+        self.assertEqual(r.returncode, 0,
+                         "decrypt of pbkdf2 stdin-password file failed: "
+                         + r.stderr)
+        with open(dec, "rb") as f:
+            self.assertEqual(f.read(), self.PLAINTEXT,
+                             "decrypted plaintext mismatch")
+
+    def test_default_kdf_stdin_decrypts_with_pass(self):
+        """Regression guard: the default (BytesToKey) path already interops
+        because the key length comes from the cipher; the fix must keep it
+        working."""
+        plain = "f5970_def_in.txt"
+        cipher = "f5970_def.bin"
+        dec = "f5970_def_out.txt"
+        self._cleanup(plain, cipher, dec)
+        self._write_plaintext(plain)
+
+        code, out = self._encrypt_with_pty_password(
+            self.PASSWORD, "aes-cbc-256", "-in", plain, "-out", cipher)
+        self.assertEqual(code, 0, "encrypt failed: " + out)
+
+        r = subprocess.run(
+            [WOLFSSL_BIN, "decrypt", "aes-cbc-256",
+             "-pass", "pass:" + self.PASSWORD, "-in", cipher, "-out", dec],
+            capture_output=True, text=True, stdin=subprocess.DEVNULL,
+            timeout=60)
+        self.assertEqual(r.returncode, 0,
+                         "decrypt of default stdin-password file failed: "
+                         + r.stderr)
+        with open(dec, "rb") as f:
+            self.assertEqual(f.read(), self.PLAINTEXT,
+                             "decrypted plaintext mismatch")
 
 
 if __name__ == "__main__":

--- a/tests/encrypt/enc-test.py
+++ b/tests/encrypt/enc-test.py
@@ -841,9 +841,10 @@ class EncStdinPasswordTest(unittest.TestCase):
     key to a couple of bytes. These tests drive the prompt over a pty.
     """
 
-    # Any human-length password truncates the bit-size keySize well below a
-    # real cipher key, so the derived key collapses to 1-2 bytes when buggy.
-    PASSWORD = "correcthorse"
+    # >= 14 chars to satisfy the FIPS HMAC minimum (HMAC_FIPS_MIN_KEY) for the
+    # PBKDF2 path, while still truncating the bit-size keySize far below a real
+    # cipher key, so the buggy derivation collapses to a few key bytes.
+    PASSWORD = "correcthorsebatterystaple"
     PLAINTEXT = b"F-5970 interactive password regression payload\n"
     # AES-256 key length in bytes.
     FULL_KEY_BYTES = 32
@@ -939,7 +940,7 @@ class EncStdinPasswordTest(unittest.TestCase):
         """A typed password with -pbkdf2 must derive the full cipher key.
 
         Before the fix keySize was overwritten by the password length, so the
-        `-p` debug print reported a 1-2 byte key instead of 32."""
+        `-p` debug print reported a few key bytes instead of 32."""
         plain = "f5970_keylen_in.txt"
         cipher = "f5970_keylen.bin"
         self._cleanup(plain, cipher)

--- a/tests/genkey_sign_ver/genkey-sign-ver-test.py
+++ b/tests/genkey_sign_ver/genkey-sign-ver-test.py
@@ -51,6 +51,36 @@ class _GenkeySignVerifyBase(unittest.TestCase):
         for f in files:
             _TEMP_FILES.append(f)
 
+    def _gen_sign_badverify(self, algo, keybase, sig_file, fmt,
+                            extra_genkey_args=None, use_output_flag=False):
+        """Generate a key, sign SIGN_FILE, then verify the (valid) signature
+        against a *different* message and assert the command fails with a
+        non-zero (non-crash) exit.
+
+        Verifying a genuine signature against tampered input produces a
+        well-formed signature that simply does not match: the verify API
+        returns successfully with stat/res != 1.  The buggy code logged
+        "Invalid Signature." but still exited 0; the fix must turn that into
+        a failure exit (F-5362)."""
+        priv, pub = self._genkey(algo, keybase, fmt, extra_genkey_args,
+                                 use_output_flag=use_output_flag)
+        self._sign(algo, priv, fmt, sig_file)
+
+        wrong_msg = keybase + "-wrong-msg.txt"
+        self._track(wrong_msg)
+        with open(wrong_msg, "w") as f:
+            f.write("Totally different data that was never signed\n")
+
+        r = run_wolfssl(f"-{algo}", "-verify", "-inkey", pub,
+                        "-inform", fmt, "-sigfile", sig_file,
+                        "-in", wrong_msg, "-pubin")
+        self.assertNotEqual(r.returncode, 0,
+                            "{} verify of a signature over different data "
+                            "should fail".format(algo))
+        self.assertGreaterEqual(r.returncode, 0,
+                                "{} bad verify crashed with signal "
+                                "{}".format(algo, r.returncode))
+
     def _genkey(self, algo, keybase, fmt, extra_args=None,
                 use_output_flag=False):
         args = ["-genkey", algo]
@@ -135,6 +165,10 @@ class Ed25519Test(_GenkeySignVerifyBase):
     def test_ed25519_raw(self):
         self._gen_sign_verify("ed25519", "edkey", "ed-signed.sig", "raw")
 
+    def test_ed25519_bad_verify(self):
+        """An Ed25519 signature that does not match must fail (F-5362)."""
+        self._gen_sign_badverify("ed25519", "edkey-bad", "ed-bad.sig", "der")
+
     def test_ed25519_signature_size(self):
         """ED25519 signatures must be exactly 64 bytes."""
         priv, pub = self._genkey("ed25519", "edkey-sztest", "der",
@@ -171,6 +205,10 @@ class EccTest(_GenkeySignVerifyBase):
 
     def test_ecc_pem(self):
         self._gen_sign_verify("ecc", "ecckey", "ecc-signed.sig", "pem")
+
+    def test_ecc_bad_verify(self):
+        """An ECC signature that does not match must fail (F-5362)."""
+        self._gen_sign_badverify("ecc", "ecckey-bad", "ecc-bad.sig", "der")
 
     def test_ecc_der_key_size_and_roundtrip(self):
         """Regression: ECC DER private key must be reasonably sized, and the
@@ -308,6 +346,15 @@ class DilithiumTest(_GenkeySignVerifyBase):
                     "dilithium", "mldsakey", "mldsa-signed.sig", "pem",
                     extra_genkey_args=["-level", str(level)],
                     skip_priv_verify=True, use_output_flag=True)
+
+    def test_dilithium_bad_verify(self):
+        """A Dilithium signature that does not match must fail (F-5362)."""
+        for level in [2, 3, 5]:
+            with self.subTest(level=level):
+                self._gen_sign_badverify(
+                    "dilithium", "mldsakey-bad", "mldsa-bad.sig", "der",
+                    extra_genkey_args=["-level", str(level)],
+                    use_output_flag=True)
 
     def test_output_pub_only(self):
         pub = "mldsakey_pub.pub"

--- a/tests/x509/x509-req-test.py
+++ b/tests/x509/x509-req-test.py
@@ -106,7 +106,8 @@ def _flip_last_der_byte(src, dst):
     the last byte corrupts the signature value while leaving every ASN.1
     length intact: the request still parses, but the signature no longer
     verifies."""
-    data = bytearray(open(src, "rb").read())
+    with open(src, "rb") as f:
+        data = bytearray(f.read())
     assert len(data) > 0, "empty DER file"
     data[-1] ^= 0xFF
     with open(dst, "wb") as f:

--- a/tests/x509/x509-req-test.py
+++ b/tests/x509/x509-req-test.py
@@ -99,6 +99,20 @@ def _cleanup(*files):
             os.remove(f)
 
 
+def _flip_last_der_byte(src, dst):
+    """Copy a DER file to dst with its final byte flipped.
+
+    A CSR's DER encoding ends with the signature BIT STRING, so flipping
+    the last byte corrupts the signature value while leaving every ASN.1
+    length intact: the request still parses, but the signature no longer
+    verifies."""
+    data = bytearray(open(src, "rb").read())
+    assert len(data) > 0, "empty DER file"
+    data[-1] ^= 0xFF
+    with open(dst, "wb") as f:
+        f.write(data)
+
+
 class TestReqNew(unittest.TestCase):
     """Test req -new with various options."""
 
@@ -403,6 +417,65 @@ class TestReqPemDerRoundTrip(unittest.TestCase):
         with open(pem_file) as f1, open(self.csr) as f2:
             self.assertEqual(f1.read(), f2.read(),
                              "PEM -> DER -> PEM round-trip mismatch")
+
+
+class TestReqVerify(unittest.TestCase):
+    """Test req -verify, including that a tampered CSR fails (F-5363)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.key = os.path.join(CERTS_DIR, "server-key.pem")
+        cls.csr_pem = _tmp("test_req_verify.csr")
+        cls.csr_der = _tmp("test_req_verify.csr.der")
+        r = run_wolfssl("req", "-new", "-key", cls.key,
+                        "-subj", "/O=wolfSSL/C=US/CN=verify-test",
+                        "-out", cls.csr_pem)
+        assert r.returncode == 0, "setup CSR creation failed: " + r.stderr
+        r = run_wolfssl("req", "-inform", "pem", "-outform", "der",
+                        "-in", cls.csr_pem, "-out", cls.csr_der)
+        assert r.returncode == 0, "setup CSR DER convert failed: " + r.stderr
+
+    @classmethod
+    def tearDownClass(cls):
+        _cleanup(cls.csr_pem, cls.csr_der)
+
+    def _clean(self, *files):
+        for f in files:
+            self.addCleanup(lambda p=f: _cleanup(p))
+
+    def test_verify_good_csr(self):
+        """A valid CSR verifies OK and exits 0."""
+        r = run_wolfssl("req", "-in", self.csr_pem, "-verify", "-noout")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("verify OK", r.stdout + r.stderr)
+
+    def test_verify_tampered_csr_der_fails(self):
+        """A CSR with a corrupted signature must fail verification (F-5363)."""
+        bad = _tmp("test_req_verify_bad.der")
+        self._clean(bad)
+        _flip_last_der_byte(self.csr_der, bad)
+
+        r = run_wolfssl("req", "-inform", "der", "-in", bad,
+                        "-verify", "-noout")
+        self.assertNotEqual(r.returncode, 0,
+                            "tampered CSR verify should fail")
+        self.assertGreaterEqual(r.returncode, 0,
+                                "tampered CSR verify crashed with signal "
+                                "{}".format(r.returncode))
+
+    def test_verify_tampered_csr_no_output(self):
+        """A failed verify must not emit the CSR even without -noout (F-5363).
+
+        Output handling is gated on the verify result, so a tampered CSR
+        produces no PEM body on stdout."""
+        bad = _tmp("test_req_verify_bad2.der")
+        self._clean(bad)
+        _flip_last_der_byte(self.csr_der, bad)
+
+        r = run_wolfssl("req", "-inform", "der", "-in", bad, "-verify")
+        self.assertNotEqual(r.returncode, 0,
+                            "tampered CSR verify should fail")
+        self.assertNotIn("BEGIN CERTIFICATE REQUEST", r.stdout)
 
 
 class TestX509ReqSign(unittest.TestCase):


### PR DESCRIPTION
Three fixes from the fenrir batch, each with tests.

### F-5362 — fail ECC/Ed25519/Dilithium verify on invalid signature
`wolfCLU_verify_signature_ecc`, `_ed25519` and `_dilithium` logged "Invalid Signature." when the underlying verify API returned successfully with `stat`/`res != 1`, but left `ret` unchanged, so the command still exited 0. The mismatch branch now sets a failure code so an invalid signature exits non-zero. Adds negative tests (verify a genuine signature against different data) for ECC, Ed25519 and Dilithium asserting a non-zero, non-crash exit.

### F-5363 — fail `req` command when CSR verification fails
`wolfCLU_requestSetup` logged "verify failed" when `wolfSSL_X509_REQ_verify` returned non-1 but left `ret` as `WOLFCLU_SUCCESS`, so `req -verify` exited 0 on a tampered CSR and still printed the request. Now sets `WOLFCLU_FATAL_ERROR` on verify failure; the later text/DER/PEM output blocks are already gated on `ret == WOLFCLU_SUCCESS` so they are skipped. Adds `TestReqVerify` covering a good CSR (verify OK, exit 0) and a corrupted-signature CSR (non-zero exit, no request emitted).

### F-5970 — stop clobbering keySize with stdin password length
`wolfCLU_setup` passed `&keySize` to `wolfCLU_GetStdinPassword`, which writes the entered password length back through that pointer, overwriting `keySize` (the algorithm key size in bits). With `-pbkdf2` the EVP derivation length `(keySize+7)/8` then collapsed to ~1-2 bytes, producing a brute-forceable AES key, and the cleanup memsets sized on `keySize` left most of the key buffer un-zeroed before free. Now passes a dedicated buffer-capacity variable so `keySize` is preserved, and uses `wolfCLU_ForceZero` for the key/pwdKey/iv wipe so it is not optimized away. Adds pty-driven tests for the interactive password prompt: the `-pbkdf2` path must derive a full-length key and interoperate with `-pass` decryption.