### PR TITLE
CA SAN Inline Parsing Added

### DIFF
--- a/src/x509/clu_config.c
+++ b/src/x509/clu_config.c
@@ -543,6 +543,76 @@ static int wolfCLU_setAltNames(WOLFSSL_X509* x509, WOLFSSL_CONF* conf,
 }
 
 
+#ifdef WOLFSSL_ALT_NAMES
+/* Apply an inline subjectAltName list to x509, e.g.
+ * "DNS:example.com,IP:10.0.0.1". Leading whitespace per entry is skipped.
+ * Buffer is tokenized in place, so callers pass a writable string. Returns
+ * WOLFCLU_SUCCESS, or WOLFCLU_FATAL_ERROR on a malformed entry so a bad SAN is
+ * never silently ignored. */
+static int wolfCLU_setInlineAltNames(WOLFSSL_X509* x509, char* val)
+{
+    int ret = WOLFCLU_SUCCESS;
+    char* token;
+    char* ptr = NULL;
+
+    if (x509 == NULL || val == NULL) {
+        return WOLFCLU_FATAL_ERROR;
+    }
+
+    token = XSTRTOK(val, ",", &ptr);
+    while (token != NULL) {
+        char* colon;
+        char* value;
+        size_t len;
+
+        /* trim whitespace around entries and trailing whitespace */
+        while (*token == ' ' || *token == '\t' || *token == '\r' || *token == '\n') {
+            token++;
+        }
+        len = XSTRLEN(token);
+        while (len > 0 && (token[len - 1] == ' ' || token[len - 1] == '\t' ||
+                           token[len - 1] == '\r' || token[len - 1] == '\n')) {
+            token[--len] = '\0';
+        }
+        colon = XSTRSTR(token, ":");
+        if (colon == NULL) {
+            wolfCLU_LogError("bad subjectAltName entry \"%s\", expected "
+                    "TYPE:value", token);
+            ret = WOLFCLU_FATAL_ERROR;
+            break;
+        }
+        *colon = '\0';
+        /* The trailing-whitespace trim above already NUL-terminated the token
+         * at the correct boundary, so value needs no second trailing trim. */
+        /* drop whitespace between the colon and the value */
+        value = colon + 1;
+        while (*value == ' ' || *value == '\t' || *value == '\r' || *value == '\n') {
+            value++;
+        }
+
+        /* Check for empty type or value after trimming */
+        if (XSTRLEN(token) == 0) {
+            wolfCLU_LogError("bad subjectAltName entry: empty type prefix");
+            ret = WOLFCLU_FATAL_ERROR;
+            break;
+        }
+        if (XSTRLEN(value) == 0) {
+            wolfCLU_LogError("bad subjectAltName entry: empty value for type \"%s\"", token);
+            ret = WOLFCLU_FATAL_ERROR;
+            break;
+        }
+
+        ret = wolfCLU_addAltName(x509, token, value);
+        if (ret != WOLFCLU_SUCCESS) {
+            break;
+        }
+        token = XSTRTOK(NULL, ",", &ptr);
+    }
+    return ret;
+}
+#endif /* WOLFSSL_ALT_NAMES */
+
+
 /* return WOLFCLU_SUCCESS on success */
 int wolfCLU_setExtensions(WOLFSSL_X509* x509, WOLFSSL_CONF* conf, char* sect)
 {
@@ -576,9 +646,40 @@ int wolfCLU_setExtensions(WOLFSSL_X509* x509, WOLFSSL_CONF* conf, char* sect)
     }
 
     current = wolfSSL_NCONF_get_string(conf, sect, "subjectAltName");
-    if (current != NULL && current[0] == '@') {
-        current = current+1;
-        ret = wolfCLU_setAltNames(x509, conf, current);
+    if (current != NULL) {
+        if (current[0] == '@') {
+            ret = wolfCLU_setAltNames(x509, conf, current + 1);
+        }
+        else {
+            /* Accept inline form for config compatibility. */
+#ifndef WOLFSSL_ALT_NAMES
+            /* Intentional: mirror the pre-existing silent-skip behaviour of
+             * the @section form (wolfCLU_setAltNames is also a no-op when
+             * WOLFSSL_ALT_NAMES is not defined).  We log the skip but do NOT
+             * promote ret to WOLFCLU_FATAL_ERROR so that a config containing
+             * a subjectAltName line is still usable in builds where alt-name
+             * support was compiled out. */
+            WOLFCLU_LOG(WOLFCLU_L0, "Skipping alt names, recompile wolfSSL "
+                    "with WOLFSSL_ALT_NAMES...");
+#else
+            {
+                int   len = (int)XSTRLEN(current);
+                char* dup = (char*)XMALLOC(len + 1, NULL,
+                        DYNAMIC_TYPE_TMP_BUFFER);
+
+                if (dup == NULL) {
+                    wolfCLU_LogError("out of memory duplicating "
+                            "subjectAltName value");
+                    ret = WOLFCLU_FATAL_ERROR;
+                }
+                else {
+                    XMEMCPY(dup, current, len + 1);
+                    ret = wolfCLU_setInlineAltNames(x509, dup);
+                    XFREE(dup, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                }
+            }
+#endif
+        }
     }
     return ret;
 }
@@ -621,26 +722,8 @@ int wolfCLU_parseAddExt(WOLFSSL_X509* x509, char* addExt)
         (void)val;
         WOLFCLU_LOG(WOLFCLU_L0, "Skipping alt names, recompile wolfSSL with WOLFSSL_ALT_NAMES...");
 #else
-        char* token;
-        char* ptr = NULL;
-
         /* value is a comma separated list of TYPE:value pairs */
-        token = XSTRTOK(val, ",", &ptr);
-        while (token != NULL) {
-            char* colon = XSTRSTR(token, ":");
-            if (colon == NULL) {
-                wolfCLU_LogError("bad subjectAltName entry \"%s\", expected "
-                        "TYPE:value", token);
-                ret = WOLFCLU_FATAL_ERROR;
-                break;
-            }
-            *colon = '\0';
-            ret = wolfCLU_addAltName(x509, token, colon + 1);
-            if (ret != WOLFCLU_SUCCESS) {
-                break;
-            }
-            token = XSTRTOK(NULL, ",", &ptr);
-        }
+        ret = wolfCLU_setInlineAltNames(x509, val);
 #endif
     }
     else {
@@ -656,9 +739,18 @@ int wolfCLU_setExtensions(WOLFSSL_X509* x509, WOLFSSL_CONF* conf, char* sect)
 {
     (void)x509;
     (void)conf;
-    (void)sect;
 
-    wolfCLU_LogError("wolfSSL not compiled with cert extensions");
+    /* No extension section requested, so not having WOLFSSL_CERT_EXT
+     * can be ignored. (Coupled with `ret = ` in wolfCLU_readConfig) */
+    if (sect == NULL) {
+        return WOLFCLU_SUCCESS;
+    }
+
+    /* If not compiled with WOLFSSL_CERT_EXT, fail so certs can be built as
+     * intended by user. */
+    wolfCLU_LogError("wolfSSL not compiled with cert extensions "
+            "(WOLFSSL_CERT_EXT); cannot apply requested x509_extensions "
+            "section \"%s\"", sect);
     return NOT_COMPILED_IN;
 }
 
@@ -918,7 +1010,11 @@ int wolfCLU_readConfig(WOLFSSL_X509* x509, char* config, char* sect, char* ext)
     wolfCLU_setAttributes(x509, conf,
             wolfSSL_NCONF_get_string(conf, sect, "attributes"));
     if (ext == NULL) {
-        (void)wolfCLU_setExtensions(x509, conf,
+        /* Note: we capture this return code because the !WOLFSSL_CERT_EXT stub
+         * of wolfCLU_setExtensions gracefully returns SUCCESS when the string
+         * is NULL, but fails loudly if an extension section IS requested and
+         * WOLFSSL_CERT_EXT is disabled. These two behaviors are coupled. */
+        ret = wolfCLU_setExtensions(x509, conf,
             wolfSSL_NCONF_get_string(conf, sect, "x509_extensions"));
     }
     else {

--- a/tests/x509/x509-process-test.py
+++ b/tests/x509/x509-process-test.py
@@ -492,13 +492,13 @@ class TestX509ProcessInvalidFiles(unittest.TestCase):
                          "output file should not be created on error")
 
     def test_4e_nonexistent_file_der(self):
-        r = run_wolfssl("x509", "-inform", "der", "-in", "ca-cert.pem",
+        r = run_wolfssl("x509", "-inform", "der", "-in", "nonexistent-file.pem",
                         "-outform", "der", "-out", "out.txt")
         self._clean("out.txt")
         self.assertNotEqual(r.returncode, 0)
 
     def test_4f_nonexistent_file_pem(self):
-        r = run_wolfssl("x509", "-inform", "pem", "-in", "ca-cert.pem",
+        r = run_wolfssl("x509", "-inform", "pem", "-in", "nonexistent-file.pem",
                         "-outform", "pem", "-out", "out.txt")
         self._clean("out.txt")
         self.assertNotEqual(r.returncode, 0)

--- a/tests/x509/x509-req-test.py
+++ b/tests/x509/x509-req-test.py
@@ -2,6 +2,7 @@
 """Tests for wolfssl req and x509 -req (converted from x509-req-test.sh)."""
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -248,6 +249,107 @@ class TestReqNew(unittest.TestCase):
         self.assertEqual(r2.returncode, 0, r2.stderr)
         self.assertIn("CA:TRUE", r2.stdout)
 
+
+    def _get_san_line(self, stdout):
+        """Return the value line that follows an 'X509v3 Subject Alternative
+        Name' header in `x509 -text` output, or None if not found."""
+        lines = stdout.splitlines()
+        for i, line in enumerate(lines):
+            if "X509v3 Subject Alternative Name" in line:
+                self.assertLess(i + 1, len(lines), "Missing SAN value line")
+                return lines[i + 1]
+        return None
+
+    def test_req_inline_subjectaltname_openssl_compat(self):
+        """A config subjectAltName in the OpenSSL inline form (TYPE:value list,
+        not the @section indirection) is accepted and applied to the cert.
+
+        Pins the behavior in wolfCLU_setExtensions (clu_config.c): the inline
+        form is parsed via the same path as -addext (wolfCLU_setInlineAltNames),
+        so an OpenSSL-style config is neither silently dropped nor rejected.
+        Whitespace after the comma must be tolerated. Skipped on builds without
+        cert extensions, where the parsing path is absent."""
+        conf = _tmp("test_req_inline_san.conf")
+        out = _tmp("test_req_inline_san.crt")
+        self._clean(conf, out)
+        with open(conf, "w", encoding="utf-8", newline="\n") as f:
+            f.write(
+                "[ req ]\n"
+                "distinguished_name = dn\n"
+                "prompt = no\n"
+                "x509_extensions = v3_ext\n"
+                "[ dn ]\n"
+                "commonName = inline-san-test\n"
+                "[ v3_ext ]\n"
+                "basicConstraints = CA:FALSE\n"
+                "subjectAltName = DNS:example.com, IP:10.0.0.1\n")
+        r = run_wolfssl("req", "-new", "-x509",
+                        "-key", os.path.join(CERTS_DIR, "server-key.pem"),
+                        "-config", conf, "-out", out)
+        combined = r.stdout + r.stderr
+        if "not compiled with cert extensions" in combined:
+            self.skipTest("cert extensions not compiled in")
+        if "WOLFSSL_ALT_NAMES" in combined:
+            self.skipTest("alt names not compiled in")
+        self.assertEqual(r.returncode, 0,
+                         "inline (OpenSSL-form) subjectAltName should be "
+                         "accepted: " + combined)
+        self.assertTrue(os.path.isfile(out) and os.path.getsize(out) > 0,
+                        "certificate should be written")
+        # The SAN must actually be present in the issued cert.
+        r2 = run_wolfssl("x509", "-in", out, "-text", "-noout")
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        san_line = self._get_san_line(r2.stdout)
+        self.assertIsNotNone(san_line, "SAN not found in cert output")
+        self.assertIn("DNS:example.com", san_line,
+                      "DNS SAN not applied from inline config form")
+        self.assertIn("IP Address:10.0.0.1", san_line,
+                      "IP SAN not applied from inline config form")
+
+    def test_req_inline_subjectaltname_trims_whitespace(self):
+        """Inline subjectAltName entries are trimmed of surrounding whitespace
+        like OpenSSL: whitespace BEFORE the comma (a trailing space on the
+        value) and AFTER the colon must not end up in the stored name. Pins the
+        trailing/leading trim in wolfCLU_setInlineAltNames (clu_config.c)."""
+        conf = _tmp("test_req_inline_san_ws.conf")
+        out = _tmp("test_req_inline_san_ws.crt")
+        self._clean(conf, out)
+        with open(conf, "w", encoding="utf-8", newline="\n") as f:
+            f.write(
+                "[ req ]\n"
+                "distinguished_name = dn\n"
+                "prompt = no\n"
+                "x509_extensions = v3_ext\n"
+                "[ dn ]\n"
+                "commonName = inline-san-ws-test\n"
+                "[ v3_ext ]\n"
+                "basicConstraints = CA:FALSE\n"
+                # space before the comma (trailing on DNS value) and after the
+                # colon (leading on IP value)
+                "subjectAltName = DNS:trim.example.com , IP: 10.0.0.1\n")
+        r = run_wolfssl("req", "-new", "-x509",
+                        "-key", os.path.join(CERTS_DIR, "server-key.pem"),
+                        "-config", conf, "-out", out)
+        combined = r.stdout + r.stderr
+        if "not compiled with cert extensions" in combined:
+            self.skipTest("cert extensions not compiled in")
+        if "WOLFSSL_ALT_NAMES" in combined:
+            self.skipTest("alt names not compiled in")
+        self.assertEqual(r.returncode, 0,
+                         "inline subjectAltName with whitespace should be "
+                         "accepted: " + combined)
+        r2 = run_wolfssl("x509", "-in", out, "-text", "-noout")
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        san_line = self._get_san_line(r2.stdout)
+        self.assertIsNotNone(san_line, "SAN not found in cert output")
+        # Extract the exact DNS value; a trailing space would make this
+        # "trim.example.com " and fail the equality (assertIn would not).
+        m = re.search(r"DNS:([^,]*)", san_line)
+        self.assertIsNotNone(m, "DNS SAN missing: " + san_line)
+        self.assertEqual(m.group(1), "trim.example.com",
+                         "DNS SAN not trimmed of surrounding whitespace")
+        self.assertIn("IP Address:10.0.0.1", san_line,
+                      "IP SAN not applied/trimmed from inline config form")
 
     def test_req_x509_addext_subject_alt_name(self):
         """req -x509 -addext subjectAltName adds IP and DNS alt names."""


### PR DESCRIPTION
Added support for parsing inline, comma-separated  subjectAltName  lists from config files, eliminating the strict need for @section indirection. It trims surrounding whitespace from values to prevent malformed SANs and includes unit tests to verify the compatibility and trimming behavior.