### PR TITLE
fix: drop redundant XMEMSET before XMSS Init

### DIFF
--- a/src/sign-verify/clu_sign.c
+++ b/src/sign-verify/clu_sign.c
@@ -880,8 +880,7 @@ int wolfCLU_sign_data_xmss(byte* data, char* out, int fSz, char* privKey)
     XmssKey key[1];
 #endif
 
-    /* init the XMSS key */
-    XMEMSET(key, 0, sizeof(XmssKey));
+    /* init the XMSS key (wc_XmssKey_Init zeroizes the struct internally) */
     ret = wc_XmssKey_Init(key, HEAP_HINT, 0);
     if (ret != 0) {
         wolfCLU_LogError("Failed to initialize XMSS Key."
@@ -1060,8 +1059,7 @@ int wolfCLU_sign_data_xmssmt(byte* data, char* out, int fSz, char* privKey)
     XmssKey key[1];
 #endif
 
-    /* init the xmss key */
-    XMEMSET(key, 0, sizeof(XmssKey));
+    /* init the xmss key (wc_XmssKey_Init zeroizes the struct internally) */
     ret = wc_XmssKey_Init(key, HEAP_HINT, 0);
     if (ret != 0) {
         wolfCLU_LogError("Failed to initialize XMSS Key.\nRET: %d", ret);


### PR DESCRIPTION
Bug: In both XMSS sign functions in `src/sign-verify/clu_sign.c`, the key struct is zeroized with `XMEMSET(key, 0, sizeof(XmssKey))` immediately before calling `wc_XmssKey_Init(key, HEAP_HINT, 0)`. This memset is redundant and reorder-fragile.

Fix: `wc_XmssKey_Init()` already zeroizes the entire struct via `ForceZero(key, sizeof(XmssKey))` before setting heap/devId/state (see `wolfcrypt/src/wc_xmss.c`). The manual XMEMSET is fully redundant, so it is removed at both sites; the comment is kept and annotated. No behavior change — Init self-zeroizes.

Build-verified: compiled the affected translation unit against a wolfSSL install with `-DWOLFSSL_HAVE_XMSS` (the config where this block is live); compiles clean (exit 0), object shows the expected `U wc_XmssKey_Init` reference.

Reported by static analysis (Fenrir finding 581).

`[fenrir-sweep:held]`
