### PR TITLE
fix: plug pkey/ca leak in CA setup error paths

### DIFF
--- a/src/x509/clu_ca_setup.c
+++ b/src/x509/clu_ca_setup.c
@@ -286,6 +286,7 @@ int wolfCLU_CASetup(int argc, char** argv)
         if (selfSigned) {
             wolfCLU_CertSignSetCA(signer, x509, pkey,
                     wolfCLU_GetTypeFromPKEY(pkey));
+            pkey = NULL; /* ownership transferred to signer */
         }
         else if (altSign) {
             char* subjName = wolfSSL_X509_NAME_oneline(
@@ -302,6 +303,8 @@ int wolfCLU_CASetup(int argc, char** argv)
         else {
             wolfCLU_CertSignSetCA(signer, ca, pkey,
                     wolfCLU_GetTypeFromPKEY(pkey));
+            ca = NULL;   /* ownership transferred to signer */
+            pkey = NULL; /* ownership transferred to signer */
         }
     }
 
@@ -335,8 +338,11 @@ int wolfCLU_CASetup(int argc, char** argv)
     if (!selfSigned) {
         wolfSSL_X509_free(x509);
     }
-    if ((selfSigned || altSign) && ca != NULL) {
+    if (ca != NULL) {
         wolfSSL_X509_free(ca);
+    }
+    if (pkey != NULL) {
+        wolfSSL_EVP_PKEY_free(pkey);
     }
 
     /* check for success on signer free since random data is output */


### PR DESCRIPTION
Bug: In `wolfCLU_CASetup()` (src/x509/clu_ca_setup.c), the local `pkey` (allocated by `wolfSSL_PEM_read_bio_PrivateKey`) and the local `ca` (`-CA` cert) are transferred to the signer struct only inside the `if (ret == WOLFCLU_SUCCESS && (pkey != NULL || ca != NULL || ...))` block. `wolfCLU_CertSignSetCA` takes ownership (see `/* take ownership of ca or key passed in */` in clu_x509_sign.c), and `wolfCLU_CertSignFree` frees them.

If `ret` goes to an error state before that transfer block runs — e.g. `wolfCLU_CertSignAppendOut` fails, or the PEM/d2i X509_REQ read yields NULL — the transfer is skipped. The cleanup section then had no `wolfSSL_EVP_PKEY_free(pkey)` at all, and freed `ca` only under the `(selfSigned || altSign)` guard, so the normal CA-signing error path leaked both.

Fix: NULL out `pkey`/`ca` immediately after each ownership transfer, then free them unconditionally (when non-NULL) in cleanup. A transferred pointer is NULL by the time cleanup runs, so it is freed by `wolfCLU_CertSignFree` instead — no double free. Pre-transfer error paths now free via cleanup.

Double-free audit: normal success -> both NULL, freed by CertSignFree; selfSigned success -> pkey NULL (freed by signer), unused `-CA` cert freed by cleanup; altSign -> pkey never allocated, ca borrowed then freed by cleanup; any pre-transfer error -> both freed by cleanup. No path frees twice.

Out of scope (pre-existing): `wolfCLU_CertSignSetCA` default keytype branch neither stores nor frees the key, so a non-RSA/ECDSA `wolfCLU_GetTypeFromPKEY` result would orphan the key regardless of this change. A successfully PEM-read RSA/ECC key returns RSAk/ECDSAk, so this fix is unaffected.

Build-verified: compiled the modified translation unit against a prebuilt wolfSSL (gcc -c, exit 0); preprocessed output confirms `wolfSSL_EVP_PKEY_free(pkey)` is now present (was absent).

Reported by static analysis (Fenrir finding 662).

`[fenrir-sweep:held]`
