### PR TITLE
fix(dh): wipe DH private key from stack

### DIFF
--- a/src/dh/clu_dh.c
+++ b/src/dh/clu_dh.c
@@ -795,6 +795,9 @@ int wolfCLU_DhParamSetup(int argc, char** argv)
             XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (outBuf != NULL)
             XFREE(outBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+
+        /* wipe DH private key material off the stack before returning */
+        wolfCLU_ForceZero(priv, sizeof(priv));
     }
 
     wolfSSL_BIO_free(bioIn);


### PR DESCRIPTION
## Bug

In `wolfCLU_DhParamSetup` (src/dh/clu_dh.c), the `genKey` block declares a stack buffer `byte priv[WOLFSSL_MAX_DH_BITS/8]` and fills it with the DH private key via `wc_DhGenerateKeyPair`. When the block ends the function returns with `priv` left un-wiped on the stack, leaking private key material.

This is the outlier in wolfCLU's own convention: private-key buffers are scrubbed with `wolfCLU_ForceZero` throughout the codebase (clu_genkey.c, clu_sign.c, clu_pkcs8/pkcs12, etc.). The DH keygen path omitted the wipe.

## Fix

Add `wolfCLU_ForceZero(priv, sizeof(priv))` immediately before the block closes, after the outBuf free. `wolfCLU_ForceZero` is already declared in wolfclu/clu_header_main.h — no new include.

## How verified

Compiled the patched translation unit against a wolfSSL `--enable-all` install (gcc -c, EXIT=0). Preprocessor + `nm` confirm the `wolfCLU_ForceZero(priv, ...)` call is live (undefined reference in the object, one call in the preprocessed output), not compiled out behind an ifdef.

Reported by static analysis (Fenrir finding 664).

`[fenrir-sweep:held]`
