### PR TITLE
fix: zero stdin password buffer in req

### DIFF
--- a/src/x509/clu_request_setup.c
+++ b/src/x509/clu_request_setup.c
@@ -1104,6 +1104,7 @@ int wolfCLU_requestSetup(int argc, char** argv)
                         ret = wolfCLU_pKeyPEMtoPriKeyEnc(keyOutBio, pkey, DES3b,
                                 pass, passwordSz);
                     }
+                    wolfCLU_ForceZero(pass, MAX_PASSWORD_SIZE);
                 }
                 else {
                     ret = wolfCLU_pKeyPEMtoPriKeyEnc(keyOutBio, pkey, DES3b,


### PR DESCRIPTION
## Bug
In `wolfCLU_requestSetup` (`src/x509/clu_request_setup.c`), the local stack buffer `byte pass[MAX_PASSWORD_SIZE]` (256 bytes) holds a password read from stdin via `wolfCLU_GetStdinPassword`. After the password is consumed by `wolfCLU_pKeyPEMtoPriKeyEnc`, the buffer goes out of scope without being cleared, leaving the plaintext password on the stack (recoverable via core dump or later stack reuse).

## Fix
Add `wolfCLU_ForceZero(pass, MAX_PASSWORD_SIZE)` after the buffer's last use, before it leaves scope. This matches the existing secure-clear convention already used elsewhere in the codebase (e.g. `src/pkey/clu_rsa.c`, `src/tools/clu_rand.c`, `src/x509/clu_x509_sign.c`).

## How verified
- Compiled the patched translation unit against a prebuilt `--enable-all` wolfSSL: `gcc -c src/x509/clu_request_setup.c` exits 0.
- `objdump -dr` on the object confirms a new relocation call to `wolfCLU_ForceZero` that was absent before the change; object size grew by the added call.

Reported by static analysis (Fenrir finding 744). A sibling uncleared buffer (function-level `password[]`, finding 663) is tracked separately and left out of scope here.

`[fenrir-sweep:held]`
