### PR TITLE
fix: zeroize EC private-key DER before free

### DIFF
--- a/src/ecparam/clu_ecparam.c
+++ b/src/ecparam/clu_ecparam.c
@@ -280,6 +280,9 @@ int wolfCLU_ecparam(int argc, char** argv)
             if (der != NULL) {
                 /* der was created by wolfSSL library so we assume
                  * that XMALLOC was used and call XFREE here */
+                if (derSz > 0) {
+                    wolfCLU_ForceZero(der, derSz);
+                }
                 XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             }
         }


### PR DESCRIPTION
## Bug

In `wolfCLU_ecparam` (`src/ecparam/clu_ecparam.c`), the `ecparam -genkey ... -outform der` path serializes the EC private key into a `der` buffer via `wolfSSL_i2d_ECPrivateKey`, writes it out, then frees it with `XFREE` **without zeroizing**. The freed heap buffer holds live private-key material.

## Fix

ForceZero the buffer before `XFREE`, matching wolfCLU's own established convention for DER private-key buffers (`src/pkey/clu_pkey.c:340`, `src/pkey/clu_rsa.c:273`, `src/ocsp/clu_ocsp.c:893`). The ecparam genkey DER path was the sole outlier. The `derSz > 0` guard is defensive since `wolfCLU_ForceZero(void*, unsigned int)` casts the length.

## How verified

Built against a full `--enable-all` wolfSSL install: `make -j8` recompiles `clu_ecparam.o` and relinks the `wolfssl` binary, exit 0. Runtime repro confirmed the pre-fix buffer held a valid 256-bit EC private key (decoded independently with OpenSSL).

Reported by static analysis (Fenrir finding 667, missing_forcezero).

`[fenrir-sweep:held]`
