### PR TITLE
fix: zeroize DSA private key buffers

### DIFF
--- a/src/dsa/clu_dsa.c
+++ b/src/dsa/clu_dsa.c
@@ -344,10 +344,14 @@ int wolfCLU_DsaParamSetup(int argc, char** argv)
             ret = WOLFCLU_FATAL_ERROR;
         }
 
-        if (pem != NULL)
+        if (pem != NULL) {
+            wolfCLU_ForceZero(pem, pemSz);
             XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        if (outBuf != NULL)
+        }
+        if (outBuf != NULL) {
+            wolfCLU_ForceZero(outBuf, outBufSz);
             XFREE(outBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
     }
 
     wolfSSL_BIO_free(bioIn);


### PR DESCRIPTION
## Bug
In `wolfCLU_DsaParamSetup` (src/dsa/clu_dsa.c), the `genKey` path serializes a freshly generated DSA key including the secret exponent x. The DER buffer (`outBuf`, populated by `wc_DsaKeyToDer`) and the PEM buffer (`pem`, `DSA_PRIVATEKEY_TYPE`) are freed at the end of the block via `XFREE` without being zeroized first. The private key material persists in freed heap.

## Fix
Call `wolfCLU_ForceZero(buf, sz)` on both buffers before `XFREE`, matching wolfCLU's existing pattern for private-key buffers elsewhere (clu_parse.c, clu_pkcs8.c, clu_genkey.c). Only the genKey block is touched; the sibling param block (lines 210-279) serializes only public params (p,q,g via `DSA_PARAM_TYPE`) and needs no change.

## Build verification
Compiled the patched translation unit clean under the project build flags against a full-featured wolfSSL install (DSA enabled). `objdump -dr src/dsa/clu_dsa.o` shows two relocations to `wolfCLU_ForceZero`, confirming the zeroize calls are live.

Reported by static analysis (Fenrir finding 665).

`[fenrir-sweep:held]`
