### PR TITLE
fix: zeroize req password buffers

### DIFF
--- a/src/x509/clu_request_setup.c
+++ b/src/x509/clu_request_setup.c
@@ -688,6 +688,7 @@ int wolfCLU_requestSetup(int argc, char** argv)
 
             case WOLFCLU_HELP:
                 wolfCLU_certgenHelp();
+                wolfCLU_ForceZero(password, MAX_PASSWORD_SIZE);
                 return WOLFCLU_SUCCESS;
 
             case WOLFCLU_RSA:
@@ -1104,6 +1105,7 @@ int wolfCLU_requestSetup(int argc, char** argv)
                         ret = wolfCLU_pKeyPEMtoPriKeyEnc(keyOutBio, pkey, DES3b,
                                 pass, passwordSz);
                     }
+                    wolfCLU_ForceZero(pass, MAX_PASSWORD_SIZE);
                 }
                 else {
                     ret = wolfCLU_pKeyPEMtoPriKeyEnc(keyOutBio, pkey, DES3b,
@@ -1130,6 +1132,7 @@ int wolfCLU_requestSetup(int argc, char** argv)
     wolfSSL_BIO_free(bioOut);
     wolfSSL_X509_free(x509);
     wolfSSL_EVP_PKEY_free(pkey);
+    wolfCLU_ForceZero(password, MAX_PASSWORD_SIZE);
     return ret;
 #endif
 }


### PR DESCRIPTION
## Bug
`wolfCLU_requestSetup` in `src/x509/clu_request_setup.c` reads a key-encryption password into stack buffers (`password[MAX_PASSWORD_SIZE]` via `-passout`, and a `pass[MAX_PASSWORD_SIZE]` stdin buffer) but never zeroizes them. The secret is left on the stack at every return path — the normal exit and the `-help` early return (reachable when `-passout` precedes `-help`). Sibling functions in this codebase already scrub such buffers with `wolfCLU_ForceZero` (see `src/pkcs/clu_pkcs8.c:290`, `src/pkcs/clu_pkcs12.c:237`).

## Fix
Call `wolfCLU_ForceZero(buf, MAX_PASSWORD_SIZE)` on each secret buffer before it goes out of scope:
- `password` before the normal `return ret`
- `password` before the `-help` early `return WOLFCLU_SUCCESS`
- the stdin `pass` buffer before it leaves its block

`wolfCLU_ForceZero` is a project-provided helper declared in the already-included `wolfclu/clu_header_main.h`; no new include or dependency.

## Verification
Compiled the patched translation unit clean against a full-featured wolfSSL install: `gcc -c src/x509/clu_request_setup.c ... -Wall` exits 0, and `nm` confirms the object now references `wolfCLU_ForceZero`.

Reported by static analysis (Fenrir finding 663).

`[fenrir-sweep:held]`
