### PR TITLE
fix: zeroize RSA private key before free

### DIFF
--- a/src/genkey/clu_genkey.c
+++ b/src/genkey/clu_genkey.c
@@ -921,8 +921,12 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
 
             XFCLOSE(file);
             file = NULL;
+            if (derBufSz > 0)
+                wolfCLU_ForceZero(derBuf, derBufSz);
             XFREE(derBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             derBuf = NULL;
+            if (pemBufSz > 0)
+                wolfCLU_ForceZero(pemBuf, pemBufSz);
             XFREE(pemBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             pemBuf = NULL;
 
@@ -1014,9 +1018,13 @@ int wolfCLU_genKey_RSA(WC_RNG* rng, char* fName, int directive, int fmt, int
         fOutNameBuf = NULL;
     }
     if (derBuf != NULL) {
+        if (derBufSz > 0)
+            wolfCLU_ForceZero(derBuf, derBufSz);
         XFREE(derBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (pemBuf != NULL) {
+        if (pemBufSz > 0)
+            wolfCLU_ForceZero(pemBuf, pemBufSz);
         XFREE(pemBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
      if (file != NULL) {


### PR DESCRIPTION
## Bug
`wolfCLU_genKey_RSA` (src/genkey/clu_genkey.c) frees the RSA private-key DER buffer (`derBuf`) and PEM buffer (`pemBuf`) with bare `XFREE`, leaving private key material in freed heap. There are ZERO `wolfCLU_ForceZero` calls anywhere in the RSA function, while every other key path in the same file (Dilithium, XMSS, ECC/Ed25519 cleanups — 30+ ForceZero sites) wipes before free. RSA was the outlier.

Two sites are affected, both holding the just-written private key:
- the fall-through free when `flagOutputPub == 1` (also emitting the public key)
- the final cleanup block

## Fix
Add `wolfCLU_ForceZero` before each `XFREE`, matching the in-file Dilithium precedent. Guarded on `size > 0` because `derBufSz`/`pemBufSz` can be negative on an error break (e.g. a failed `wc_RsaKeyToDer`) and `wolfCLU_ForceZero` takes an `unsigned int` length — a bare call would overwrite past the allocation. `wolfCLU_ForceZero` is already declared in wolfclu/clu_header_main.h and defined in src/tools/clu_funcs.c; no new include. Both hunks stay inside the existing `#ifndef NO_RSA` region.

## Verification
Patched `src/genkey/clu_genkey.c` compiles clean (`gcc -c`) against an `--enable-all` wolfSSL install; `nm` shows `wolfCLU_ForceZero` now referenced from the RSA TU and `wolfCLU_genKey_RSA` defined.

Reported by static analysis (Fenrir finding 666).

`[fenrir-sweep:held]`
