### PR TITLE
small changes to get build working on MSYS2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - '--enable-wolfclu --enable-experimental --enable-dilithium'
           - '--enable-wolfclu --enable-smallstack --enable-experimental --enable-dilithium'
           - '--enable-all'
-        sanitize: ['CC="cc -fsanitize=address"']
+        sanitize: ['CC="cc -fsanitize=address" CFLAGS="-g"']
         include:
           - os: ubuntu-latest
             config: '--enable-wolfclu'

--- a/autogen.sh
+++ b/autogen.sh
@@ -26,9 +26,8 @@ fi
 
 autoreconf --install --force --verbose -I m4 -I config
 
-#where: 
+#where:
 # --force rebuilds ./configure regardless
 # --install copies some missing files to the directory including txt files
 # -I config tells tools to look in the config directory instead of root
 # -I m4 '... see -I config ...'
-

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,9 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
 
+# The following sets CFLAGS to empty if unset on command line.  We do not
+# want the default "-g -O2" that AC_PROG_CC sets automatically.
+: ${CFLAGS=""}
 
 AM_INIT_AUTOMAKE([1.14.1 -Wall -Werror -Wno-portability foreign tar-ustar subdir-objects no-define color-tests])
 
@@ -58,6 +61,8 @@ AM_PROG_CC_C_O
 AM_PATH_PYTHON([3.6],, [:])
 AC_SUBST([PYTHON])
 AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != ":"])
+
+OPTIMIZE_CFLAGS="-O2"
 
 # Checks for headers/libraries
 AC_CHECK_HEADERS([sys/time.h string.h termios.h unistd.h])
@@ -163,6 +168,11 @@ AX_HARDEN_CC_COMPILER_FLAGS
 if test "$GCC" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -Wall -Wno-unused"
+
+    if test "$ax_enable_debug" = "no"
+    then
+        AM_CFLAGS="$AM_CFLAGS $OPTIMIZE_CFLAGS"
+    fi
 fi
 
 CREATE_HEX_VERSION
@@ -198,3 +208,4 @@ echo "   * C Compiler:                $CC_VERSION"
 echo "   * C Flags:                   $CFLAGS"
 echo "   * CPP Flags:                 $CPPFLAGS"
 echo "   * LIB Flags:                 $LIB"
+echo "   * Debug enabled:             $ax_enable_debug"

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -373,7 +373,7 @@ static WC_INLINE void clu_tcp_connect(SOCKET_T* sockfd, const char* ip,
         clu_build_addr(NULL, &ipv6, ip, port, udp, sctp);
         clu_tcp_socket(sockfd, udp, sctp, isIpv6);
         if (!udp) {
-            if (*sockfd < 0)
+            if (WOLFSSL_SOCKET_IS_INVALID(*sockfd))
                 err_sys_with_errno("tcp bad socket");
 
             if (connect(*sockfd, (const struct sockaddr*)&ipv6, sizeof(ipv6))
@@ -389,7 +389,7 @@ static WC_INLINE void clu_tcp_connect(SOCKET_T* sockfd, const char* ip,
         clu_tcp_socket(sockfd, udp, sctp, isIpv6);
 
         if (!udp) {
-            if (*sockfd < 0)
+            if (WOLFSSL_SOCKET_IS_INVALID(*sockfd))
                 err_sys_with_errno("tcp bad socket");
 
             if (connect(*sockfd, (const struct sockaddr*)&addr, sizeof(addr))

--- a/wolfclu/clu_header_main.h
+++ b/wolfclu/clu_header_main.h
@@ -30,18 +30,17 @@ extern "C" {
 #include <stdio.h>
 
 #ifdef _WIN32 /* running on windows */
-#include <winsock2.h>
-#include <windows.h>
-#include <corecrt_io.h>
-#include <sys/timeb.h>
-
+    #include <winsock2.h>
+    #include <windows.h>
+    #include <sys/timeb.h>
+    #include <io.h>
 #else
-#include <unistd.h>
-#include <sys/time.h>
-#ifndef FREERTOS
-#include <termios.h>
-#endif
-#endif
+    #include <unistd.h>
+    #include <sys/time.h>
+    #ifndef FREERTOS
+        #include <termios.h>
+    #endif
+#endif /* _WIN32 */
 
 #undef CRL_REASON_UNSPECIFIED
 #undef CRL_REASON_KEY_COMPROMISE
@@ -177,7 +176,9 @@ struct option
 
 #define int64_t long long
 #define access _access
+#ifndef F_OK
 #define F_OK 00
+#endif
 #define strtok_r strtok_s
 
 extern char* optarg;


### PR DESCRIPTION
MSYS2 MINGW64 fails compilation due to a couple things:
* Header issues
* if (*sockfd < 0) does not evaluate properly
* And function from libtool missing a qualifier

### Header issues

<corecrt_io.h> should not be included directly, MSYS2 also doesn't have it. Moved this over to <io.h> which should be including <corecrt_io.h>

F_OK is redefined. Wrapped this in '#ifndef'

### Evaluation issue

*sockfd is compared to 0 but this doesn't work well for Windows since sockfd is an unsigned int. Moved over to the WOLFSSL_SOCKET_IS_INVALID() macro.

### configure.ac

CFLAGS is automatically set to "-g -O2" if configure.ac does not set it. Mimicked wolfssl's behavior and set it to empty. This resolves the libtool compilation error since it isn't compiled with"-O2" now.

Ended up changing other configure.ac / workflow stuff to resolve some skoll reviews.