### PR TITLE
Fix: removed unneccesary memset from clu_sign.c

### DIFF
--- a/src/benchmark/clu_benchmark.c
+++ b/src/benchmark/clu_benchmark.c
@@ -60,8 +60,6 @@ int wolfCLU_benchmark(int timer, int* option)
 
     byte*           digest;         /* message digest */
 
-    XMEMSET(&rng, 0, sizeof(rng));
-
     if (wc_InitRng(&rng) != 0) {
         return WOLFCLU_FATAL_ERROR;
     }

--- a/src/genkey/clu_genkey.c
+++ b/src/genkey/clu_genkey.c
@@ -1700,7 +1700,6 @@ int wolfCLU_genKey_XMSS(WC_RNG* rng, char* fName,
 
     /* init the xmss key */
     if (ret == 0) {
-        XMEMSET(key, 0, sizeof(XmssKey));
         ret = wc_XmssKey_Init(key, HEAP_HINT, 0);
         if (ret != 0) {
             wolfCLU_LogError("Failed to initialize XMSS Key."

--- a/src/pkey/clu_pkey.c
+++ b/src/pkey/clu_pkey.c
@@ -167,8 +167,6 @@ static int wolfCLU_DerToEncryptedPEM(WOLFSSL_BIO* bio, byte* key, word32 keySz,
     int itt       = WC_PKCS12_ITT_DEFAULT;
     void* heap    = NULL;
 
-    XMEMSET(&rng, 0, sizeof(rng));
-
     if (wc_InitRng(&rng) != 0) {
         ret = WOLFCLU_FATAL_ERROR;
     }

--- a/src/sign-verify/clu_dgst_setup.c
+++ b/src/sign-verify/clu_dgst_setup.c
@@ -470,7 +470,6 @@ static int wolfCLU_dgstSignVerify(WOLFSSL_BIO* dataBio, WOLFSSL_BIO* pubKeyBio,
     /* create the signature if requested */
     if (ret == WOLFCLU_SUCCESS && signing == 1) {
         WC_RNG rng;
-        XMEMSET(&rng, 0, sizeof(rng));
 
         if (wc_InitRng(&rng) != 0) {
             wolfCLU_LogError("Error initializing RNG");

--- a/src/sign-verify/clu_sign.c
+++ b/src/sign-verify/clu_sign.c
@@ -929,7 +929,6 @@ int wolfCLU_sign_data_xmss(byte* data, char* out, int fSz, char* privKey)
 #endif
 
     /* init the XMSS key */
-    XMEMSET(key, 0, sizeof(XmssKey));
     ret = wc_XmssKey_Init(key, HEAP_HINT, 0);
     if (ret != 0) {
         wolfCLU_LogError("Failed to initialize XMSS Key."
@@ -1109,7 +1108,6 @@ int wolfCLU_sign_data_xmssmt(byte* data, char* out, int fSz, char* privKey)
 #endif
 
     /* init the xmss key */
-    XMEMSET(key, 0, sizeof(XmssKey));
     ret = wc_XmssKey_Init(key, HEAP_HINT, 0);
     if (ret != 0) {
         wolfCLU_LogError("Failed to initialize XMSS Key.\nRET: %d", ret);

--- a/src/sign-verify/clu_sign.c
+++ b/src/sign-verify/clu_sign.c
@@ -212,7 +212,6 @@ int wolfCLU_sign_data_rsa(byte* data, char* out, word32 dataSz, char* privKey,
     int   outBufSz = 0;
 
     XMEMSET(&rng, 0, sizeof(rng));
-    XMEMSET(&key, 0, sizeof(key));
 
     /* initialize the RSA key */
     ret = wc_InitRsaKey(&key, NULL);
@@ -749,7 +748,6 @@ int wolfCLU_sign_data_dilithium (byte* data, char* out, word32 dataSz, char* pri
 #endif
 
     XMEMSET(&rng, 0, sizeof(rng));
-    XMEMSET(key, 0, sizeof(dilithium_key));
 
     /* init the dilithium key */
     ret = wc_dilithium_init(key);
@@ -885,8 +883,8 @@ int wolfCLU_sign_data_dilithium (byte* data, char* out, word32 dataSz, char* pri
     }
 
     wc_dilithium_free(key);
-    /* rng zeroed via XMEMSET before wc_InitRng, so even if wc_InitRng failed:
-     * wolfSSL checks rng->drbg internally before freeing. */
+    /* rng zeroed via XMEMSET before wc_InitRng, because wc_InitRsaKey can
+     * fail leaving rng un inited and not zeroed. */
     wc_FreeRng(&rng);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);

--- a/src/sign-verify/clu_verify.c
+++ b/src/sign-verify/clu_verify.c
@@ -361,8 +361,6 @@ int wolfCLU_verify_signature_rsa(byte* sig, char* out, int sigSz, char* keyPath,
     byte* outBuf = NULL;
     int   outBufSz = 0;
 
-    XMEMSET(&key, 0, sizeof(key));
-
     /* initialize RSA key */
     ret = wc_InitRsaKey(&key, NULL);
     if (ret != 0) {
@@ -1030,7 +1028,6 @@ int wolfCLU_verify_signature_xmss(byte* sig, int sigSz,
 #endif
 
     /* init the xmss key */
-    XMEMSET(key, 0, sizeof(XmssKey));
     ret = wc_XmssKey_Init(key, HEAP_HINT, 0);
     if (ret != 0) {
         wolfCLU_LogError("Failed to initialize XMSS Key.\nRET: %d", ret);
@@ -1198,7 +1195,6 @@ int wolfCLU_verify_signature_xmssmt(byte* sig, int sigSz,
 #endif
 
     /* init the xmss key */
-    XMEMSET(key, 0, sizeof(XmssKey));
     ret = wc_XmssKey_Init(key, HEAP_HINT, 0);
     if (ret != 0) {
         wolfCLU_LogError("Failed to initialize XMSS Key.\nRET: %d", ret);


### PR DESCRIPTION
wc_XmssKey_Init(...) sets the input key to zero at the top of the function